### PR TITLE
7 fsk pair

### DIFF
--- a/STM32/Core/Inc/frequency_pairs.h
+++ b/STM32/Core/Inc/frequency_pairs.h
@@ -1,0 +1,71 @@
+#ifndef FREQUENCY_PAIRS_H
+#define FREQUENCY_PAIRS_H
+
+//-----------------------------------------------------------//
+//------------ DO NOT MODIFY BELOW THIS FILE ----------------//
+//-----------------------------------------------------------//
+
+#define MAX_NUM_SAMPLES 720
+
+// ---------------- Frequency Pair 1 ---------------- //
+// 21.0 kHz (S=48, PER_HALF=15)
+// 22.2 kHz (S=45, PER_HALF=16)
+#define SAMPLES_21000 48
+#define SAMPLES_22222 45
+#define PER_HALF_21000 (MAX_NUM_SAMPLES / SAMPLES_21000) // 15
+#define PER_HALF_22222 (MAX_NUM_SAMPLES / SAMPLES_22222) // 16
+
+// ---------------- Frequency Pair 2 ---------------- //
+// 12.5 kHz (S=80, PER_HALF=9)
+// 11.1 kHz (S=90, PER_HALF=8)
+#define SAMPLES_12500 80
+#define SAMPLES_11111 90
+#define PER_HALF_12500 (MAX_NUM_SAMPLES / SAMPLES_12500) // 9
+#define PER_HALF_11111 (MAX_NUM_SAMPLES / SAMPLES_11111) // 8
+
+// ---------------- Frequency Pair 3 ---------------- //
+// 8.3 kHz (S=120, PER_HALF=6)
+// 6.9 kHz (S=144, PER_HALF=5)
+#define SAMPLES_8333 120
+#define SAMPLES_6944 144
+#define PER_HALF_8333 (MAX_NUM_SAMPLES / SAMPLES_8333) // 6
+#define PER_HALF_6944 (MAX_NUM_SAMPLES / SAMPLES_6944) // 5
+
+// ---------------- Frequency Pair 4 ---------------- //
+// 2.8 kHz (S=360, PER_HALF=2)
+// 1.4 kHz (S=720, PER_HALF=1)
+#define SAMPLES_2778 360
+#define SAMPLES_1389 720
+#define PER_HALF_2778 (MAX_NUM_SAMPLES / SAMPLES_2778) // 2
+#define PER_HALF_1389 (MAX_NUM_SAMPLES / SAMPLES_1389) // 1
+
+// ---------------- Selection Logic ---------------- //
+
+#if FSK_FREQUENCY_PAIR == 1
+#define MAX_SAMPLES_LOW SAMPLES_21000
+#define MAX_SAMPLES_HIGH SAMPLES_22222
+#define PER_HALF_LOW PER_HALF_21000
+#define PER_HALF_HIGH PER_HALF_22222
+#elif FSK_FREQUENCY_PAIR == 2
+#define MAX_SAMPLES_LOW SAMPLES_12500
+#define MAX_SAMPLES_HIGH SAMPLES_11111
+#define PER_HALF_LOW PER_HALF_12500
+#define PER_HALF_HIGH PER_HALF_11111
+#elif FSK_FREQUENCY_PAIR == 3
+#define MAX_SAMPLES_LOW SAMPLES_8333
+#define MAX_SAMPLES_HIGH SAMPLES_6944
+#define PER_HALF_LOW PER_HALF_8333
+#define PER_HALF_HIGH PER_HALF_6944
+#elif FSK_FREQUENCY_PAIR == 4
+#define MAX_SAMPLES_LOW SAMPLES_2778
+#define MAX_SAMPLES_HIGH SAMPLES_1389
+#define PER_HALF_LOW PER_HALF_2778
+#define PER_HALF_HIGH PER_HALF_1389
+#else
+#define MAX_SAMPLES_LOW SAMPLES_21000
+#define MAX_SAMPLES_HIGH SAMPLES_22222
+#define PER_HALF_LOW PER_HALF_21000
+#define PER_HALF_HIGH PER_HALF_22222
+#endif
+
+#endif // FREQUENCY_PAIRS_H

--- a/STM32/Core/Inc/frequency_pairs.h
+++ b/STM32/Core/Inc/frequency_pairs.h
@@ -5,39 +5,39 @@
 //------------ DO NOT MODIFY BELOW THIS FILE ----------------//
 //-----------------------------------------------------------//
 
-#define MAX_NUM_SAMPLES 720
+#define MAX_NUM_SAMPLES_BUFFER 720
 
 // ---------------- Frequency Pair 1 ---------------- //
 // 21.0 kHz (S=48, PER_HALF=15)
 // 22.2 kHz (S=45, PER_HALF=16)
 #define SAMPLES_21000 48
 #define SAMPLES_22222 45
-#define PER_HALF_21000 (MAX_NUM_SAMPLES / SAMPLES_21000) // 15
-#define PER_HALF_22222 (MAX_NUM_SAMPLES / SAMPLES_22222) // 16
+#define PER_HALF_21000 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_21000) // 15
+#define PER_HALF_22222 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_22222) // 16
 
 // ---------------- Frequency Pair 2 ---------------- //
 // 12.5 kHz (S=80, PER_HALF=9)
 // 11.1 kHz (S=90, PER_HALF=8)
 #define SAMPLES_12500 80
 #define SAMPLES_11111 90
-#define PER_HALF_12500 (MAX_NUM_SAMPLES / SAMPLES_12500) // 9
-#define PER_HALF_11111 (MAX_NUM_SAMPLES / SAMPLES_11111) // 8
+#define PER_HALF_12500 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_12500) // 9
+#define PER_HALF_11111 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_11111) // 8
 
 // ---------------- Frequency Pair 3 ---------------- //
 // 8.3 kHz (S=120, PER_HALF=6)
 // 6.9 kHz (S=144, PER_HALF=5)
 #define SAMPLES_8333 120
 #define SAMPLES_6944 144
-#define PER_HALF_8333 (MAX_NUM_SAMPLES / SAMPLES_8333) // 6
-#define PER_HALF_6944 (MAX_NUM_SAMPLES / SAMPLES_6944) // 5
+#define PER_HALF_8333 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_8333) // 6
+#define PER_HALF_6944 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_6944) // 5
 
 // ---------------- Frequency Pair 4 ---------------- //
 // 2.8 kHz (S=360, PER_HALF=2)
 // 1.4 kHz (S=720, PER_HALF=1)
 #define SAMPLES_2778 360
 #define SAMPLES_1389 720
-#define PER_HALF_2778 (MAX_NUM_SAMPLES / SAMPLES_2778) // 2
-#define PER_HALF_1389 (MAX_NUM_SAMPLES / SAMPLES_1389) // 1
+#define PER_HALF_2778 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_2778) // 2
+#define PER_HALF_1389 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_1389) // 1
 
 // ---------------- Selection Logic ---------------- //
 

--- a/STM32/Core/Inc/user_config.h
+++ b/STM32/Core/Inc/user_config.h
@@ -23,6 +23,12 @@
 #define INCLUDE_LOCATION true
 #define INCLUDE_TEMPERATURE true
 
-//-------------------------------------------------------//
+// Configuration for FSK frequency pair
+// Options:
+// 1 = 21kHz and 22kHz (Default)
+// 2 = 12.5kHz and 11.1kHz
+// 3 = 8.3kHz and 6.9kHz
+// 4 = 2.8kHz and 1.4kHz
+#define FSK_FREQUENCY_PAIR 1
 
 #endif // USER_CONFIG_H

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -21,14 +21,15 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include <user_config.h>
 
+#include <frequency_pairs.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <user_config.h>
 
 /* USER CODE END Includes */
 
@@ -53,18 +54,12 @@
 
 #define MID_12B 2048
 
-#define BUF_LEN 720
-
-#define MAX_SAMPLES_21k 48
-#define MAX_SAMPLES_22k 45
 #define MAX_SAMPLES_MID_VAL 20
 
 #define REPEAT_HALF 4
-#define PER_HALF_21K 15
-#define PER_HALF_22K 16
 #define PER_HALF_SIL 18
-#define PERIODS_PER_BIT_21K (PER_HALF_21K * REPEAT_HALF)
-#define PERIODS_PER_BIT_22K (PER_HALF_22K * REPEAT_HALF)
+#define PERIODS_PER_BIT_LOW (PER_HALF_LOW * REPEAT_HALF)
+#define PERIODS_PER_BIT_HIGH (PER_HALF_HIGH * REPEAT_HALF)
 #define PERIODS_PER_BIT_SIL (PER_HALF_SIL * REPEAT_HALF)
 
 #define BIT_POLARITY 0 // 0 = normal, 1 = inverted
@@ -89,10 +84,10 @@ TIM_HandleTypeDef htim8;
 /* USER CODE BEGIN PV */
 
 // Circular buffer for DAC output
-__ALIGN_BEGIN __IO uint16_t output_buffer[2 * BUF_LEN] __ALIGN_END;
+__ALIGN_BEGIN __IO uint16_t output_buffer[2 * MAX_NUM_SAMPLES_BUFFER] __ALIGN_END;
 
-uint16_t sine_val_21k[MAX_SAMPLES_21k];
-uint16_t sine_val_22k[MAX_SAMPLES_22k];
+uint16_t sine_val_21k[MAX_SAMPLES_LOW];
+uint16_t sine_val_22k[MAX_SAMPLES_HIGH];
 uint16_t dc_mid[MAX_SAMPLES_MID_VAL];
 
 static uint16_t bitstream[BITSTREAM_LENGTH];
@@ -166,17 +161,17 @@ void make_bitstream_from_string(const char *str) {
 
 // Function to generate sine wave lookup table for 21kHz
 void get_sineval_21k(void) {
-  for (int i = 0; i < MAX_SAMPLES_21k; i++) {
+  for (int i = 0; i < MAX_SAMPLES_LOW; i++) {
     sine_val_21k[i] = (uint16_t)((4095.0 / 2.0) *
-                                 (1.0 + sinf(2.0 * pi * i / MAX_SAMPLES_21k)));
+                                 (1.0 + sinf(2.0 * pi * i / MAX_SAMPLES_LOW)));
   }
 }
 
 // Function to generate sine wave lookup table for 22kHz
 void get_sineval_22k(void) {
-  for (int i = 0; i < MAX_SAMPLES_22k; i++) {
+  for (int i = 0; i < MAX_SAMPLES_HIGH; i++) {
     sine_val_22k[i] = (uint16_t)((4095.0 / 2.0) *
-                                 (1.0 + sinf(2.0 * pi * i / MAX_SAMPLES_22k)));
+                                 (1.0 + sinf(2.0 * pi * i / MAX_SAMPLES_HIGH)));
   }
 }
 
@@ -188,21 +183,17 @@ void get_dc_mid(void) {
 
 // Function to calculate the total time it takes to send the bitstream
 void calculate_pulse_time(void) {
-  float f21k = 21000.0f;
-  float f22k = 22000.0f;
-  // float f25k = 25000.0f;
+  float f_0 = 1000000.0f / (float)MAX_SAMPLES_LOW;  // Low freq, e.g., 21kHz
+  float f_1 = 1000000.0f / (float)MAX_SAMPLES_HIGH; // High freq, e.g., 22kHz
 
   // Exact bitstream time
   total_time = 0.0f;
   for (int i = 0; i < BITSTREAM_LENGTH; ++i) {
     if (bitstream[i] == 0) {
-      total_time += (float)PERIODS_PER_BIT_21K / f21k;
+      total_time += ((float)PERIODS_PER_BIT_LOW) / f_0;
     } else if (bitstream[i] == 1) {
-      total_time += (float)PERIODS_PER_BIT_22K / f22k;
+      total_time += (float)PERIODS_PER_BIT_HIGH / f_1;
     }
-    // else { // bit == 2 (silence)
-    //   total_time += (float)PERIODS_PER_BIT_SIL / f25k;
-    // }
   }
 
   // Add some margin for safety
@@ -235,12 +226,12 @@ static inline void fill_lut_repeated(uint16_t *dst, size_t buffer_len,
 // Function to fill half of the output buffer based on the current bit
 static inline void fill_half(uint16_t *dst, uint32_t bit) {
   if (bit == 2) {
-    for (size_t i = 0; i < BUF_LEN; ++i)
+    for (size_t i = 0; i < MAX_NUM_SAMPLES_BUFFER; ++i)
       dst[i] = MID_12B;
   } else if (bit == 1) {
-    fill_lut_repeated(dst, BUF_LEN, sine_val_22k, MAX_SAMPLES_22k); // 16×
+    fill_lut_repeated(dst, MAX_NUM_SAMPLES_BUFFER, sine_val_22k, MAX_SAMPLES_HIGH); // 16×
   } else {
-    fill_lut_repeated(dst, BUF_LEN, sine_val_21k, MAX_SAMPLES_21k); // 15×
+    fill_lut_repeated(dst, MAX_NUM_SAMPLES_BUFFER, sine_val_21k, MAX_SAMPLES_LOW); // 15×
   }
 }
 
@@ -250,15 +241,15 @@ void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef *hdac) {
     return;
 
   // Update current period
-  uint32_t per = (current_bit == 0)   ? PER_HALF_21K
-                 : (current_bit == 1) ? PER_HALF_22K
+  uint32_t per = (current_bit == 0)   ? PER_HALF_LOW
+                 : (current_bit == 1) ? PER_HALF_HIGH
                                       : PER_HALF_SIL;
 
   current_period += per;
 
   // Check if we need to move to the next bit
-  while ((current_bit == 0 && current_period >= PERIODS_PER_BIT_21K) ||
-         (current_bit == 1 && current_period >= PERIODS_PER_BIT_22K) ||
+  while ((current_bit == 0 && current_period >= PERIODS_PER_BIT_LOW) ||
+         (current_bit == 1 && current_period >= PERIODS_PER_BIT_HIGH) ||
          (current_bit == 2 && current_period >= PERIODS_PER_BIT_SIL)) {
     current_period = 0;
     current_idx = (current_idx + 1) % BITSTREAM_LENGTH;
@@ -275,15 +266,15 @@ void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef *hdac) {
     return;
 
   // Update current period
-  uint32_t per = (current_bit == 0)   ? PER_HALF_21K
-                 : (current_bit == 1) ? PER_HALF_22K
+  uint32_t per = (current_bit == 0)   ? PER_HALF_LOW
+                 : (current_bit == 1) ? PER_HALF_HIGH
                                       : PER_HALF_SIL;
 
   current_period += per;
 
   // Check if we need to move to the next bit
-  while ((current_bit == 0 && current_period >= PERIODS_PER_BIT_21K) ||
-         (current_bit == 1 && current_period >= PERIODS_PER_BIT_22K) ||
+  while ((current_bit == 0 && current_period >= PERIODS_PER_BIT_LOW) ||
+         (current_bit == 1 && current_period >= PERIODS_PER_BIT_HIGH) ||
          (current_bit == 2 && current_period >= PERIODS_PER_BIT_SIL)) {
     current_period = 0;
     current_idx = (current_idx + 1) % BITSTREAM_LENGTH;
@@ -291,7 +282,7 @@ void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef *hdac) {
   }
 
   // Fill the first half of the buffer based on the current bit
-  fill_half((uint16_t *)&output_buffer[BUF_LEN], current_bit);
+  fill_half((uint16_t *)&output_buffer[MAX_NUM_SAMPLES_BUFFER], current_bit);
 }
 
 void reset_dac(void) {
@@ -305,7 +296,7 @@ void reset_dac(void) {
 
   // Prefill both halves of the circular buffer with the first bit
   fill_half((uint16_t *)&output_buffer[0], current_bit);
-  fill_half((uint16_t *)&output_buffer[BUF_LEN], current_bit);
+  fill_half((uint16_t *)&output_buffer[MAX_NUM_SAMPLES_BUFFER], current_bit);
 
   __HAL_TIM_SET_COUNTER(&htim2, 0);
   HAL_TIM_Base_Start(&htim2);
@@ -313,7 +304,7 @@ void reset_dac(void) {
 
   // Restart DAC with the circular buffer
   HAL_DAC_Start_DMA(&hdac1, DAC_CHANNEL_1, (uint32_t *)output_buffer,
-                    2 * BUF_LEN, DAC_ALIGN_12B_R);
+                    2 * MAX_NUM_SAMPLES_BUFFER, DAC_ALIGN_12B_R);
 }
 
 int counter = 0;
@@ -488,14 +479,14 @@ int main(void) {
 
   // prefill both halves of the circular buffer with the first bit
   fill_half((uint16_t *)&output_buffer[0], current_bit);
-  fill_half((uint16_t *)&output_buffer[BUF_LEN], current_bit);
+  fill_half((uint16_t *)&output_buffer[MAX_NUM_SAMPLES_BUFFER], current_bit);
 
   //-------------------------------------------------------------------------------------------//
   // Start DAC with the circular buffer
   //-------------------------------------------------------------------------------------------//
 
   HAL_DAC_Start_DMA(&hdac1, DAC_CHANNEL_1, (uint32_t *)output_buffer,
-                    2 * BUF_LEN, DAC_ALIGN_12B_R);
+                    2 * MAX_NUM_SAMPLES_BUFFER, DAC_ALIGN_12B_R);
 
   //-------------------------------------------------------------------------------------------//
   // Set the DAC output to mid-scale before starting


### PR DESCRIPTION
This pull request introduces configurable FSK frequency pairs to the STM32 codebase, allowing selection of different frequency pairs via a single macro in `user_config.h`. The changes replace hardcoded frequency values and buffer sizes throughout the code with macros that are set according to the selected frequency pair, improving flexibility and maintainability.

**FSK Frequency Pair Configuration:**

* Added the `FSK_FREQUENCY_PAIR` macro to `user_config.h`, enabling selection between four different frequency pairs for FSK modulation.
* Created a new header file `frequency_pairs.h` that defines all relevant sample counts and buffer sizes for each frequency pair, and sets the active macros based on the selected pair.

**Refactoring for Frequency Pair Selection:**

* Updated all buffer size and frequency-related macros in `main.c` to use the new macros from `frequency_pairs.h`, replacing hardcoded values (e.g., `BUF_LEN`, `MAX_SAMPLES_21k`, `PER_HALF_21K`) with `MAX_NUM_SAMPLES_BUFFER`, `MAX_SAMPLES_LOW`, `MAX_SAMPLES_HIGH`, `PER_HALF_LOW`, and `PER_HALF_HIGH`. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L56-R62) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L92-R90) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L169-R174) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L191-L205) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L238-R234) [[6]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L253-R252) [[7]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L278-R285) [[8]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L308-R307) [[9]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L491-R489)

**Code Organization:**

* Moved frequency configuration logic out of `main.c` and into dedicated header files for better separation of concerns and easier future modifications. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R24-L31) [[2]](diffhunk://#diff-fe47609ecfb7d77c8bcf68e90ae0fa3e32918ba018b72ddcef6f9252085eff2cR1-R71)