### PR TITLE
Update starting minute configuration and adjust related logic main.c

### DIFF
--- a/STM32/Core/Inc/user_config.h
+++ b/STM32/Core/Inc/user_config.h
@@ -16,8 +16,8 @@
 #define INITIAL_YEAR 2025 // Year (e.g. 2024)
 
 // Configuration for which minute in the hour to start transmissions (0-59)
-#define ENABLE_DELAYED_START false 
-#define INITIAL_MINUTE 0 
+#define ENABLE_DELAYED_START false
+#define STARTING_MINUTE 0
 
 // Configuration for the interval between repeats
 #define USE_DEFAULT_INTERVAL_BETWEEN_REPEATS true // Default is 60 seconds

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -404,10 +404,7 @@ void reset_dac(void) {
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
   if (htim->Instance == TIM8) {
     update_time_temperature();
-    if (!ENABLE_DELAYED_START) {
-      first_run = false;
-    }
-    if (first_run && now.minutes != INITIAL_MINUTE) {
+    if (first_run && now.minutes != STARTING_MINUTE && ENABLE_DELAYED_START) {
       counter = INTERVAL_BETWEEN_REPEATS_MINUTES;
       HAL_DAC_Start(&hdac1, DAC_CHANNEL_1);
       HAL_DAC_SetValue(&hdac1, DAC_CHANNEL_1, DAC_ALIGN_12B_R, MID_12B);


### PR DESCRIPTION
This pull request updates the configuration and logic for controlling the delayed start of transmissions in the STM32 project. The main changes improve code clarity and ensure that the delayed start feature is only activated when explicitly enabled.

Configuration improvements:

* Renamed the macro `INITIAL_MINUTE` to `STARTING_MINUTE` in `user_config.h` for clearer intent and consistency with related configuration options.

Logic corrections:

* Updated the conditional logic in the timer callback in `main.c` to check both `first_run`, the new `STARTING_MINUTE`, and `ENABLE_DELAYED_START`, ensuring the delayed start logic only runs when enabled and the minute does not match the configured starting minute.