### PR TITLE
Add toggle functionality for transmission options in GUI

### DIFF
--- a/Python/gui/gui.py
+++ b/Python/gui/gui.py
@@ -158,15 +158,25 @@ tk.Label(
     transmission_frame, text="Transmission Settings", font=("Arial", 15, "bold")
 ).grid(row=0, column=0, sticky="w", pady=(0, 5))
 
+
+def toggle_transmission(selected_var):
+    if selected_var == root.use_cable_transmission:
+        root.use_speaker_transmission.set(0)
+    else:
+        root.use_cable_transmission.set(0)
+
+
 tk.Checkbutton(
     transmission_frame,
     text="Use Cable Transmission",
     variable=root.use_cable_transmission,
+    command=lambda: toggle_transmission(root.use_cable_transmission),
 ).grid(row=1, column=0, sticky="w")
 tk.Checkbutton(
     transmission_frame,
     text="Use Speaker Transmission",
     variable=root.use_speaker_transmission,
+    command=lambda: toggle_transmission(root.use_speaker_transmission),
 ).grid(row=2, column=0, sticky="w")
 
 


### PR DESCRIPTION
This pull request updates the transmission settings in the GUI to ensure that only one transmission method (cable or speaker) can be selected at a time. This improves the user experience by preventing conflicting options from being enabled simultaneously.

**Transmission settings logic:**

* Added a `toggle_transmission` function in `gui.py` that ensures when one transmission method is selected, the other is automatically deselected.
* Updated the `command` parameter for both "Use Cable Transmission" and "Use Speaker Transmission" checkboxes to call `toggle_transmission`, enforcing mutual exclusivity between the two options.