### PR TITLE
88 better selection of frequency pairs

### DIFF
--- a/STM32/Core/Inc/frequency_pairs.h
+++ b/STM32/Core/Inc/frequency_pairs.h
@@ -6,66 +6,9 @@
 //-----------------------------------------------------------//
 
 #define MAX_NUM_SAMPLES_BUFFER 720
-
-// ---------------- Frequency Pair 1 ---------------- //
-// 21.0 kHz (S=48, PER_HALF=15)
-// 22.2 kHz (S=45, PER_HALF=16)
-#define SAMPLES_21000 48
-#define SAMPLES_22222 45
-#define PER_HALF_21000 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_21000) // 15
-#define PER_HALF_22222 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_22222) // 16
-
-// ---------------- Frequency Pair 2 ---------------- //
-// 12.5 kHz (S=80, PER_HALF=9)
-// 11.1 kHz (S=90, PER_HALF=8)
-#define SAMPLES_12500 80
-#define SAMPLES_11111 90
-#define PER_HALF_12500 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_12500) // 9
-#define PER_HALF_11111 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_11111) // 8
-
-// ---------------- Frequency Pair 3 ---------------- //
-// 8.3 kHz (S=120, PER_HALF=6)
-// 6.9 kHz (S=144, PER_HALF=5)
-#define SAMPLES_8333 120
-#define SAMPLES_6944 144
-#define PER_HALF_8333 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_8333) // 6
-#define PER_HALF_6944 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_6944) // 5
-
-// ---------------- Frequency Pair 4 ---------------- //
-// 2.8 kHz (S=360, PER_HALF=2)
-// 1.4 kHz (S=720, PER_HALF=1)
-#define SAMPLES_2778 360
-#define SAMPLES_1389 720
-#define PER_HALF_2778 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_2778) // 2
-#define PER_HALF_1389 (MAX_NUM_SAMPLES_BUFFER / SAMPLES_1389) // 1
-
-// ---------------- Selection Logic ---------------- //
-
-#if FSK_FREQUENCY_PAIR == 1
-#define MAX_SAMPLES_LOW SAMPLES_21000
-#define MAX_SAMPLES_HIGH SAMPLES_22222
-#define PER_HALF_LOW PER_HALF_21000
-#define PER_HALF_HIGH PER_HALF_22222
-#elif FSK_FREQUENCY_PAIR == 2
-#define MAX_SAMPLES_LOW SAMPLES_11111
-#define MAX_SAMPLES_HIGH SAMPLES_12500
-#define PER_HALF_LOW PER_HALF_11111
-#define PER_HALF_HIGH PER_HALF_12500
-#elif FSK_FREQUENCY_PAIR == 3
-#define MAX_SAMPLES_LOW SAMPLES_6944
-#define MAX_SAMPLES_HIGH SAMPLES_8333
-#define PER_HALF_LOW PER_HALF_6944
-#define PER_HALF_HIGH PER_HALF_8333
-#elif FSK_FREQUENCY_PAIR == 4
-#define MAX_SAMPLES_LOW SAMPLES_1389
-#define MAX_SAMPLES_HIGH SAMPLES_2778
-#define PER_HALF_LOW PER_HALF_1389
-#define PER_HALF_HIGH PER_HALF_2778
-#else
-#define MAX_SAMPLES_LOW SAMPLES_21000
-#define MAX_SAMPLES_HIGH SAMPLES_22222
-#define PER_HALF_LOW PER_HALF_21000
-#define PER_HALF_HIGH PER_HALF_22222
-#endif
+#define FS_HZ 1000000u
+#define MIN_BIT_US 3000u
+#define MIN_BIT_SAMPLES ((FS_HZ * MIN_BIT_US) / 1000000u) // = 3000
+#define MAX_BIT_DURATION_SAMPLES MIN_BIT_SAMPLES
 
 #endif // FREQUENCY_PAIRS_H

--- a/STM32/Core/Inc/user_config.h
+++ b/STM32/Core/Inc/user_config.h
@@ -40,12 +40,7 @@
 #define USE_CABLE_TRANSMISSION true
 #define USE_SPEAKER_TRANSMISSION true
 
-// Configuration for FSK frequency pair
-// Options:
-// 1 = 20.8kHz and 22.2kHz (Default)
-// 2 = 12.5kHz and 11.1kHz
-// 3 = 8.3kHz and 6.9kHz
-// 4 = 2.8kHz and 1.4kHz
-#define FSK_FREQUENCY_PAIR 1
+#define FSK_LOWER_FREQUENCY 1234  // in Hz
+#define FSK_HIGHER_FREQUENCY 8442 // in Hz
 
 #endif // USER_CONFIG_H

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -62,16 +62,28 @@
 
 #define MID_12B 2048
 
-#define MAX_SAMPLES_MID_VAL 20
-
-#define REPEAT_HALF 4
-#define PER_HALF_SIL 18
-#define PERIODS_PER_BIT_LOW (PER_HALF_LOW * REPEAT_HALF)
-#define PERIODS_PER_BIT_HIGH (PER_HALF_HIGH * REPEAT_HALF)
-#define PERIODS_PER_BIT_SIL (PER_HALF_SIL * REPEAT_HALF)
-
 #define BIT_POLARITY 0          // 0 = normal, 1 = inverted
 #define DS3231_ADDR (0x68 << 1) // 7-bit addr shifted for HAL
+
+#define DIV_FLOOR(n, d) ((uint32_t)((n) / (d)))
+#define DIV_ROUND(n, d) ((uint32_t)(((n) + ((d) / 2u)) / (d))) // round half-up
+
+#define FSK_LOWER_NUM_SAMPLES DIV_FLOOR(FS_HZ, FSK_LOWER_FREQUENCY)
+#define FSK_HIGHER_NUM_SAMPLES DIV_FLOOR(FS_HZ, FSK_HIGHER_FREQUENCY)
+
+#define FSK_LOWER_PERIODS DIV_ROUND(MIN_BIT_SAMPLES, FSK_LOWER_NUM_SAMPLES)
+#define FSK_HIGHER_PERIODS DIV_ROUND(MIN_BIT_SAMPLES, FSK_HIGHER_NUM_SAMPLES)
+
+#define OUTPUT_SEGMENT 1000
+#define BUFFER_SIZE (OUTPUT_SEGMENT * 5)
+
+// Add/keep these near your defines
+#define DMA_BUF_LEN (BUFFER_SIZE)
+
+// (Optional but recommended) make sure it's even at compile time
+#if (DMA_BUF_LEN % 2u) != 0u
+#error "BUFFER_SIZE must be even (so it can be split into two halves)."
+#endif
 
 /* USER CODE END PD */
 
@@ -95,18 +107,16 @@ TIM_HandleTypeDef htim8;
 /* USER CODE BEGIN PV */
 
 // Circular buffer for DAC output
-__ALIGN_BEGIN __IO uint16_t
-    output_buffer[2 * MAX_NUM_SAMPLES_BUFFER] __ALIGN_END;
+__ALIGN_BEGIN __IO uint16_t output_buffer[BUFFER_SIZE] __ALIGN_END;
 
-uint16_t sine_val_low[MAX_SAMPLES_LOW];
-uint16_t sine_val_high[MAX_SAMPLES_HIGH];
-uint16_t dc_mid[MAX_SAMPLES_MID_VAL];
+uint16_t sine_val_low[FSK_LOWER_NUM_SAMPLES];
+uint16_t sine_val_high[FSK_HIGHER_NUM_SAMPLES];
+uint16_t dc_mid[FSK_LOWER_NUM_SAMPLES];
 
 static uint16_t bitstream[BITSTREAM_LENGTH];
 
 static volatile uint32_t current_period = 1;
-static volatile uint32_t current_bit = 2;
-static volatile uint32_t current_idx = 0;
+static volatile uint16_t current_bit = 2;
 
 float total_time = 0.0;
 uint32_t pulse_time = 1000; // in timer ticks
@@ -117,7 +127,6 @@ uint32_t ticks = 0;
 static volatile bool tx_active = false;
 
 int counter = INTERVAL_BETWEEN_REPEATS_MINUTES;
-int delay_counter = 0;
 bool first_run = true;
 
 // User string buffer
@@ -131,6 +140,23 @@ uint32_t fs = 0;
 
 float f_0_bit_duration = 0.0f;
 float f_1_bit_duration = 0.0f;
+float f_2_bit_duration = 0.0f;
+
+uint32_t current_bitstream_index = 0;
+
+bool moved_to_next_bit = false;
+
+typedef struct {
+  bool moved_to_next_bit;
+  size_t current_period;
+  size_t current_index;
+} FillResult;
+
+FillResult result = {false, 0, 0};
+
+size_t current_sine_period = 0;
+size_t current_sine_index = 0;
+uint16_t next_bit = 2;
 
 /* USER CODE END PV */
 
@@ -282,25 +308,27 @@ void update_input_string(void) {
 
 // Function to generate sine wave lookup table for low frequency
 void get_sineval_low(void) {
-  for (int i = 0; i < MAX_SAMPLES_LOW; i++) {
+  for (int i = 0; i < FSK_LOWER_NUM_SAMPLES; i++) {
     sine_val_low[i] =
         (uint16_t)((4095.0 / 2.0) *
-                   (1.0 + sinf(2.0 * pi * i / MAX_SAMPLES_LOW) * (1.5 / 1.65)));
+                   (1.0 +
+                    sinf(2.0 * pi * i / FSK_LOWER_NUM_SAMPLES) * (1.5 / 1.65)));
   }
 }
 
 // Function to generate sine wave lookup table for the high frequency
 void get_sineval_high(void) {
-  for (int i = 0; i < MAX_SAMPLES_HIGH; i++) {
-    sine_val_high[i] = (uint16_t)((4095.0 / 2.0) *
-                                  (1.0 + sinf(2.0 * pi * i / MAX_SAMPLES_HIGH) *
-                                             (1.5 / 1.65)));
+  for (int i = 0; i < FSK_HIGHER_NUM_SAMPLES; i++) {
+    sine_val_high[i] =
+        (uint16_t)((4095.0 / 2.0) *
+                   (1.0 + sinf(2.0 * pi * i / FSK_HIGHER_NUM_SAMPLES) *
+                              (1.5 / 1.65)));
   }
 }
 
 // Function to generate mid-scale lookup table
 void get_dc_mid(void) {
-  for (int i = 0; i < MAX_SAMPLES_MID_VAL; ++i)
+  for (int i = 0; i < FSK_LOWER_NUM_SAMPLES; ++i)
     dc_mid[i] = MID_12B;
 }
 
@@ -316,19 +344,22 @@ uint32_t get_dac_sample_rate_hz(void) {
 void calculate_pulse_time(void) {
   fs = get_dac_sample_rate_hz();
 
-  float f_0 = (float)fs / (float)MAX_SAMPLES_LOW;
-  float f_1 = (float)fs / (float)MAX_SAMPLES_HIGH;
+  float f_0 = FSK_LOWER_FREQUENCY;
+  float f_1 = FSK_HIGHER_FREQUENCY;
 
-  f_0_bit_duration = (float)PERIODS_PER_BIT_LOW / f_0;
-  f_1_bit_duration = (float)PERIODS_PER_BIT_HIGH / f_1;
+  f_0_bit_duration = (float)FSK_LOWER_PERIODS / f_0;
+  f_1_bit_duration = (float)FSK_HIGHER_PERIODS / f_1;
+  f_2_bit_duration = f_0_bit_duration; // silence uses lower frequency
 
   // Exact bitstream time
   total_time = 0.0f;
   for (int i = 0; i < BITSTREAM_LENGTH; ++i) {
     if (bitstream[i] == 0) {
-      total_time += ((float)PERIODS_PER_BIT_LOW) / f_0;
+      total_time += ((float)FSK_LOWER_PERIODS) / f_0;
     } else if (bitstream[i] == 1) {
-      total_time += (float)PERIODS_PER_BIT_HIGH / f_1;
+      total_time += (float)FSK_HIGHER_PERIODS / f_1;
+    } else {
+      total_time += (float)FSK_LOWER_PERIODS / f_0;
     }
   }
 
@@ -349,29 +380,75 @@ void calculate_pulse_time(void) {
   __HAL_TIM_SET_COMPARE(&htim8, TIM_CHANNEL_1, pulse_time);
 }
 
-// Function to fill a buffer with repeated patterns from a lookup table
-static inline void fill_lut_repeated(uint16_t *dst, size_t buffer_len,
-                                     const uint16_t *lut, size_t lut_len) {
-  size_t k = 0;
-  while (k < buffer_len) {
-    size_t to_copy = (buffer_len - k < lut_len) ? (buffer_len - k) : lut_len;
-    memcpy(&dst[k], lut, to_copy * sizeof(uint16_t));
-    k += to_copy;
+size_t get_target_bit_periods(uint16_t bit) {
+  if (bit == 0) {
+    return FSK_LOWER_PERIODS;
+  } else if (bit == 1) {
+    return FSK_HIGHER_PERIODS;
+  } else {
+    return FSK_LOWER_PERIODS; // silence uses lower frequency periods
   }
 }
 
-// Function to fill half of the output buffer based on the current bit
-static inline void fill_half(uint16_t *dst, uint32_t bit) {
-  if (bit == 2) {
-    for (size_t i = 0; i < MAX_NUM_SAMPLES_BUFFER; ++i)
-      dst[i] = MID_12B;
-  } else if (bit == 1) {
-    fill_lut_repeated(dst, MAX_NUM_SAMPLES_BUFFER, sine_val_high,
-                      MAX_SAMPLES_HIGH); // 16×
-  } else {
-    fill_lut_repeated(dst, MAX_NUM_SAMPLES_BUFFER, sine_val_low,
-                      MAX_SAMPLES_LOW); // 15×
+#include <string.h>
+
+FillResult fill_half_buffer(uint16_t *buffer, uint16_t bit, uint16_t next_bit,
+                            size_t generation_size, size_t current_sine_period,
+                            size_t current_sine_index) {
+  size_t out = 0;
+  size_t period = current_sine_period;
+  size_t idx = current_sine_index;
+  uint16_t cur_bit = bit;
+  bool moved = false;
+
+  while (out < generation_size) {
+
+    /* Select LUT */
+    const uint16_t *lut;
+    size_t lut_len;
+    size_t target_periods;
+
+    if (cur_bit == 0) {
+      lut = sine_val_low;
+      lut_len = FSK_LOWER_NUM_SAMPLES;
+      target_periods = FSK_LOWER_PERIODS;
+    } else if (cur_bit == 1) {
+      lut = sine_val_high;
+      lut_len = FSK_HIGHER_NUM_SAMPLES;
+      target_periods = FSK_HIGHER_PERIODS;
+    } else {
+      lut = dc_mid;
+      lut_len = FSK_LOWER_NUM_SAMPLES; // constant value
+      target_periods = FSK_LOWER_PERIODS;
+    }
+
+    /* How many samples can we copy this round? */
+    size_t left_buf = generation_size - out;
+    size_t left_lut = lut_len - idx;
+    size_t n = left_buf < left_lut ? left_buf : left_lut;
+
+    memcpy(&buffer[out], &lut[idx], n * sizeof(uint16_t));
+
+    out += n;
+    idx += n;
+
+    /* Wrapped LUT = completed one period */
+    if (idx == lut_len) {
+      idx = 0;
+      period++;
+
+      /* Completed all periods for this bit */
+      if (period == target_periods) {
+        period = 0;
+        cur_bit = next_bit;
+        moved = true;
+      }
+    }
   }
+
+  return (FillResult){.moved_to_next_bit = moved,
+                      .current_period = period,
+                      .current_index = idx};
 }
 
 // DAC conversion complete callbacks for half buffer
@@ -379,24 +456,21 @@ void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef *hdac) {
   if (!tx_active)
     return;
 
-  // Update current period
-  uint32_t per = (current_bit == 0)   ? PER_HALF_LOW
-                 : (current_bit == 1) ? PER_HALF_HIGH
-                                      : PER_HALF_SIL;
-
-  current_period += per;
-
-  // Check if we need to move to the next bit
-  while ((current_bit == 0 && current_period >= PERIODS_PER_BIT_LOW) ||
-         (current_bit == 1 && current_period >= PERIODS_PER_BIT_HIGH) ||
-         (current_bit == 2 && current_period >= PERIODS_PER_BIT_SIL)) {
-    current_period = 0;
-    current_idx = (current_idx + 1) % BITSTREAM_LENGTH;
-    current_bit = bitstream[current_idx];
-  }
-
   // Fill the first half of the buffer based on the current bit
-  fill_half((uint16_t *)&output_buffer[0], current_bit);
+  result = fill_half_buffer((uint16_t *)&output_buffer[0], current_bit,
+                            next_bit, BUFFER_SIZE / 2, current_sine_period,
+                            current_sine_index);
+
+  moved_to_next_bit = result.moved_to_next_bit;
+  current_sine_period = result.current_period;
+  current_sine_index = result.current_index;
+
+  if (moved_to_next_bit) {
+    moved_to_next_bit = false;
+    current_bitstream_index = (current_bitstream_index + 1) % BITSTREAM_LENGTH;
+    current_bit = bitstream[current_bitstream_index];
+    next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+  }
 }
 
 // DAC conversion complete callback for the full buffer
@@ -404,24 +478,21 @@ void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef *hdac) {
   if (!tx_active)
     return;
 
-  // Update current period
-  uint32_t per = (current_bit == 0)   ? PER_HALF_LOW
-                 : (current_bit == 1) ? PER_HALF_HIGH
-                                      : PER_HALF_SIL;
-
-  current_period += per;
-
-  // Check if we need to move to the next bit
-  while ((current_bit == 0 && current_period >= PERIODS_PER_BIT_LOW) ||
-         (current_bit == 1 && current_period >= PERIODS_PER_BIT_HIGH) ||
-         (current_bit == 2 && current_period >= PERIODS_PER_BIT_SIL)) {
-    current_period = 0;
-    current_idx = (current_idx + 1) % BITSTREAM_LENGTH;
-    current_bit = bitstream[current_idx];
-  }
-
   // Fill the first half of the buffer based on the current bit
-  fill_half((uint16_t *)&output_buffer[MAX_NUM_SAMPLES_BUFFER], current_bit);
+  result = fill_half_buffer((uint16_t *)&output_buffer[BUFFER_SIZE / 2],
+                            current_bit, next_bit, BUFFER_SIZE / 2,
+                            current_sine_period, current_sine_index);
+
+  moved_to_next_bit = result.moved_to_next_bit;
+  current_sine_period = result.current_period;
+  current_sine_index = result.current_index;
+
+  if (moved_to_next_bit) {
+    moved_to_next_bit = false;
+    current_bitstream_index = (current_bitstream_index + 1) % BITSTREAM_LENGTH;
+    current_bit = bitstream[current_bitstream_index];
+    next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+  }
 }
 
 void reset_dac(void) {
@@ -429,13 +500,42 @@ void reset_dac(void) {
   HAL_DAC_Stop_DMA(&hdac1, DAC_CHANNEL_1);
 
   // Restart the bitstream from the beginning
-  current_idx = 0;
   current_period = 0;
+  current_bitstream_index = 0;
   current_bit = bitstream[0];
+  next_bit = bitstream[1 % BITSTREAM_LENGTH];
+  current_sine_period = 0;
+  current_sine_index = 0;
 
   // Prefill both halves of the circular buffer with the first bit
-  fill_half((uint16_t *)&output_buffer[0], current_bit);
-  fill_half((uint16_t *)&output_buffer[MAX_NUM_SAMPLES_BUFFER], current_bit);
+  result = fill_half_buffer((uint16_t *)&output_buffer[0], current_bit,
+                            next_bit, BUFFER_SIZE / 2, 0, 0);
+
+  moved_to_next_bit = result.moved_to_next_bit;
+  current_sine_period = result.current_period;
+  current_sine_index = result.current_index;
+
+  if (moved_to_next_bit) {
+    moved_to_next_bit = false;
+    current_bitstream_index = (current_bitstream_index + 1) % BITSTREAM_LENGTH;
+    current_bit = bitstream[current_bitstream_index];
+    next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+  }
+
+  result = fill_half_buffer((uint16_t *)&output_buffer[BUFFER_SIZE / 2],
+                            current_bit, next_bit, BUFFER_SIZE / 2,
+                            current_sine_period, current_sine_index);
+
+  moved_to_next_bit = result.moved_to_next_bit;
+  current_sine_period = result.current_period;
+  current_sine_index = result.current_index;
+
+  if (moved_to_next_bit) {
+    moved_to_next_bit = false;
+    current_bitstream_index = (current_bitstream_index + 1) % BITSTREAM_LENGTH;
+    current_bit = bitstream[current_bitstream_index];
+    next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+  }
 
   __HAL_TIM_SET_COUNTER(&htim2, 0);
   HAL_TIM_Base_Start(&htim2);
@@ -444,7 +544,7 @@ void reset_dac(void) {
 
   // Restart DAC with the circular buffer
   HAL_DAC_Start_DMA(&hdac1, DAC_CHANNEL_1, (uint32_t *)output_buffer,
-                    2 * MAX_NUM_SAMPLES_BUFFER, DAC_ALIGN_12B_R);
+                    BUFFER_SIZE, DAC_ALIGN_12B_R);
 }
 
 // Timer interrupt callback for TIM8
@@ -636,14 +736,42 @@ int main(void) {
   // Filling the circular buffer for the DAC
   //-------------------------------------------------------------------------------------------//
 
-  // initialize state variables
-  current_idx = 0;
-  current_period = 2;
-  current_bit = bitstream[current_idx];
+  current_sine_period = 0;
+  current_sine_index = 0;
+  current_bitstream_index = 0;
 
-  // prefill both halves of the circular buffer with the first bit
-  fill_half((uint16_t *)&output_buffer[0], current_bit);
-  fill_half((uint16_t *)&output_buffer[MAX_NUM_SAMPLES_BUFFER], current_bit);
+  current_bit = bitstream[current_bitstream_index];
+  next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+
+  result = fill_half_buffer((uint16_t *)&output_buffer[0], current_bit,
+                            next_bit, BUFFER_SIZE / 2, current_sine_period,
+                            current_sine_index);
+
+  moved_to_next_bit = result.moved_to_next_bit;
+  current_sine_period = result.current_period;
+  current_sine_index = result.current_index;
+
+  if (moved_to_next_bit) {
+    moved_to_next_bit = false;
+    current_bitstream_index = (current_bitstream_index + 1) % BITSTREAM_LENGTH;
+    current_bit = bitstream[current_bitstream_index];
+    next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+  }
+
+  result = fill_half_buffer((uint16_t *)&output_buffer[BUFFER_SIZE / 2],
+                            current_bit, next_bit, BUFFER_SIZE / 2,
+                            current_sine_period, current_sine_index);
+
+  moved_to_next_bit = result.moved_to_next_bit;
+  current_sine_period = result.current_period;
+  current_sine_index = result.current_index;
+
+  if (moved_to_next_bit) {
+    moved_to_next_bit = false;
+    current_bitstream_index = (current_bitstream_index + 1) % BITSTREAM_LENGTH;
+    current_bit = bitstream[current_bitstream_index];
+    next_bit = bitstream[(current_bitstream_index + 1) % BITSTREAM_LENGTH];
+  }
 
   //-------------------------------------------------------------------------------------------//
   // Start timers and interrupts


### PR DESCRIPTION
This pull request refactors the FSK signal generation code to support arbitrary, user-configurable frequencies, replacing the previous hardcoded frequency pairs. It introduces a more flexible buffer filling mechanism and simplifies the configuration and management of bitstream transmission. The changes improve maintainability, make the code more adaptable to different frequency requirements, and enhance buffer management for DMA-based DAC output.

**Key changes:**

### 1. Frequency Configuration Modernization
- Removed all hardcoded FSK frequency pairs and associated logic from `frequency_pairs.h`, replacing them with generic, user-configurable frequency macros (`FSK_LOWER_FREQUENCY` and `FSK_HIGHER_FREQUENCY`) and calculation helpers for sample counts and bit durations. (`STM32/Core/Inc/frequency_pairs.h`, `STM32/Core/Inc/user_config.h`) [[1]](diffhunk://#diff-fe47609ecfb7d77c8bcf68e90ae0fa3e32918ba018b72ddcef6f9252085eff2cL9-R12) [[2]](diffhunk://#diff-8e14104f0cb3c335ca6e9653cc048977c71cf8c451e0e58d44effee3364b3349L43-R44)

### 2. Buffer and Lookup Table Refactoring
- Buffer sizes and sine lookup tables are now dynamically sized based on the selected frequencies, improving flexibility and correctness for arbitrary frequency choices. (`STM32/Core/Src/main.c`) [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L98-R119) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L285-R331)
- The output buffer is now sized with `BUFFER_SIZE` and checked for evenness at compile time to ensure DMA compatibility. (`STM32/Core/Src/main.c`)

### 3. Flexible Buffer Filling Logic
- Replaced the old period/bitstream management and buffer filling logic with a new, generalized `fill_half_buffer` function and supporting state-tracking structures, allowing smooth handling of arbitrary frequencies and bit transitions. (`STM32/Core/Src/main.c`)
- Updated DAC DMA callbacks and initialization routines to use the new buffer filling logic and state management, ensuring correct operation for any configured frequencies. (`STM32/Core/Src/main.c`) [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L352-R538) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L639-R774) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L447-R547)

### 4. Bitstream and Period Handling Improvements
- All period and duration calculations are now derived from the user-configured frequencies, with bit durations and periods recalculated accordingly. (`STM32/Core/Src/main.c`)
- State variables for bitstream position, period, and index are refactored for clarity and correctness with the new logic. (`STM32/Core/Src/main.c`)

### 5. Code Cleanup and Removal of Deprecated Logic
- Removed obsolete macros, variables, and functions related to the previous hardcoded frequency pair system and buffer management. (`STM32/Core/Inc/frequency_pairs.h`, `STM32/Core/Src/main.c`) [[1]](diffhunk://#diff-fe47609ecfb7d77c8bcf68e90ae0fa3e32918ba018b72ddcef6f9252085eff2cL9-R12) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L65-R87) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L120)

These changes make the codebase more maintainable and adaptable for future requirements, especially when experimenting with different FSK frequencies.