### PR TITLE
96 make relay be on all the time

### DIFF
--- a/STM32/Core/Inc/frequency_config.h
+++ b/STM32/Core/Inc/frequency_config.h
@@ -5,6 +5,7 @@
 #define FREQUENCY_CONFIG_H
 
 #include "user_config.h"
+
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -20,4 +21,4 @@ typedef struct {
 
 freq_pair_t find_frequency_pair(uint32_t fs);
 
-#endif // DEBUG
+#endif // FREQUENCY_CONFIG_H

--- a/STM32/Core/Inc/relay.h
+++ b/STM32/Core/Inc/relay.h
@@ -1,0 +1,19 @@
+#ifndef __RELAY_H
+#define __RELAY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stm32g4xx_hal.h>
+
+void turn_on_relay(void);
+void turn_off_relay(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __RELAY_H */

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -22,35 +22,39 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 
+// Include headers for custom modules
+#include "cc1101.h"
+#include "ds3231.h"
 #include "error_codes.h"
-#include <cc1101.h>
-#include <ds3231.h>
-#include <frequency_config.h>
-#include <ism.h>
-#include <ism_config_433.h>
-#include <led_feedback.h>
-#include <log.h>
-#include <radio.h>
-#include <spi.h>
-#include <sys/types.h>
-#include <user_config.h>
+#include "frequency_config.h"
+#include "ism.h"
+#include "ism_config_433.h"
+#include "led_feedback.h"
+#include "log.h"
+#include "radio.h"
+#include "relay.h"
+#include "spi.h"
+#include "user_config.h"
 
-#include "cmsis_gcc.h"
-#include "stdlib.h"
-#include "stm32g431xx.h"
-#include "stm32g4xx.h"
-#include "stm32g4xx_hal.h"
-#include "stm32g4xx_hal_dac.h"
-#include "stm32g4xx_hal_def.h"
-#include "stm32g4xx_hal_gpio.h"
-#include "sys/_intsup.h"
+// Standard library includes
+#include <cmsis_gcc.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <stm32g431xx.h>
+#include <stm32g4xx.h>
+#include <stm32g4xx_hal.h>
+#include <stm32g4xx_hal_dac.h>
+#include <stm32g4xx_hal_def.h>
+#include <stm32g4xx_hal_gpio.h>
 #include <string.h>
+#include <sys/_intsup.h>
+#include <sys/types.h>
 #include <unistd.h>
+
 
 /* USER CODE END Includes */
 
@@ -315,6 +319,10 @@ int main(void) {
   // Get_Time(&now);
   // LOGF("-------------------------\r\n");
 
+  //-----------------------------------------------------------------------------//
+  // Initialize radio
+  //-----------------------------------------------------------------------------//
+
   HAL_Delay(20);
   int8_t init_result = init_radio(RX);
   if (init_result != 0) {
@@ -323,6 +331,18 @@ int main(void) {
     LOGF("--------------------------\r\n");
     Error_Handler_Code(init_result);
   }
+
+  //-----------------------------------------------------------------------------//
+  // If RX, set relay to mixing mode
+  //-----------------------------------------------------------------------------//
+
+  if (RX) {
+    turn_on_relay();
+  }
+
+  //-----------------------------------------------------------------------------//
+  // Main loop
+  //-----------------------------------------------------------------------------//
 
   LOGF("Entering main loop...\r\n");
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -55,7 +55,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/STM32/Core/Src/relay.c
+++ b/STM32/Core/Src/relay.c
@@ -1,0 +1,27 @@
+#include "relay.h"
+#include "log.h"
+
+#include <stm32g4xx_hal.h>
+
+#define RELAY_GPIO_Port GPIOA
+#define RELAY_PIN_ON GPIO_PIN_5
+#define RELAY_PIN_OFF GPIO_PIN_6
+#define RELAY_TOGGLE_DELAY_MS 100
+
+void turn_on_relay(void) {
+  HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_SET);
+  HAL_Delay(RELAY_TOGGLE_DELAY_MS);
+  HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_OFF, GPIO_PIN_RESET);
+
+  LOGF("Set relay to mixing mode\r\n");
+  LOGF("--------------------------\r\n");
+}
+
+void turn_off_relay(void) {
+  HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_OFF, GPIO_PIN_SET);
+  HAL_Delay(RELAY_TOGGLE_DELAY_MS);
+  HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_OFF, GPIO_PIN_RESET);
+
+  LOGF("Set relay to bypass mode\r\n");
+  LOGF("--------------------------\r\n");
+}


### PR DESCRIPTION
This pull request introduces a new relay control module and integrates relay initialization into the main application flow. It also cleans up and standardizes header includes and fixes a header guard typo. The most important changes are grouped below:

**Relay Control Module:**

* Added a new relay control module with `relay.h` and `relay.c`, providing `turn_on_relay()` and `turn_off_relay()` functions to control relay hardware and log status changes. (`STM32/Core/Inc/relay.h`, `STM32/Core/Src/relay.c`) [[1]](diffhunk://#diff-f321703b2d9f8ad55b50f65a32a028415047b4f966d4ca3b0a324598954e024eR1-R19) [[2]](diffhunk://#diff-28fa8c74636e76815084ce93e969f115ffa949e31bc151b44a629d97768e540aR1-R27)
* Integrated relay control into `main.c`, turning on the relay in mixing mode when in RX mode during initialization. (`STM32/Core/Src/main.c`)

**Code Organization and Include Cleanup:**

* Standardized and reorganized header includes in `main.c`, separating custom module headers from standard library headers for clarity and maintainability. (`STM32/Core/Src/main.c`)

**Bug Fixes and Minor Improvements:**

* Fixed a typo in the header guard for `frequency_config.h` (`#endif // FREQUENCY_CONFIG_H` instead of `#endif // DEBUG`). (`STM32/Core/Inc/frequency_config.h`)
* Added a missing newline between includes in `frequency_config.h` for formatting consistency. (`STM32/Core/Inc/frequency_config.h`)
* Added section comments in `main.c` to clarify initialization steps. (`STM32/Core/Src/main.c`)