### PR TITLE
Implement error handling and EXTI interrupt for GPIO

### DIFF
--- a/STM32/Core/Src/battery.c
+++ b/STM32/Core/Src/battery.c
@@ -31,7 +31,7 @@ void is_battery_low(ADC_HandleTypeDef *hadc1) {
   uint16_t voltage_mV = Read_Battery_Voltage_mV(hadc1);
   if (voltage_mV < LOW_BATTERY_THRESHOLD_MV) {
     LOGF("Battery voltage is low: %u mV\r\n", voltage_mV);
-    // Error_Handler_Code(STATUS_CODE_BATTERY_LOW);
+    Error_Handler_Code(STATUS_CODE_BATTERY_LOW);
   }
   return;
 }

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -291,7 +291,7 @@ int main(void) {
   // Indicate boot complete with LED blinks
   //-----------------------------------------------------------------------------//
 
-  // LED_BlinkStatusCode(STATUS_CODE_OK); // code 0 = "0000" = 4 short blinks
+  LED_BlinkStatusCode(STATUS_CODE_OK); // code 0 = "0000" = 4 short blinks
 
   //-----------------------------------------------------------------------------//
   // Find and set FSK frequencies based on user config and sample count
@@ -312,7 +312,7 @@ int main(void) {
   if (init_luts_from_freqpair() != 0) {
     LOGF("LUT alloc failed\r\n");
     LOGF("--------------------------\r\n");
-    // Error_Handler_Code(STATUS_CODE_LUT_ALLOC_FAIL);
+    Error_Handler_Code(STATUS_CODE_LUT_ALLOC_FAIL);
   }
 
   get_sineval_low();
@@ -340,11 +340,11 @@ int main(void) {
   HAL_Delay(20);
   int8_t init_result = init_radio(RX_MODE);
   if (init_result != 0) {
-    LOGF("Failed to initialize radio in RX mode, error code: %d\r\n",
-         init_result);
+    LOGF("Failed to initialize radio in %s mode, error code: %d\r\n",
+         RX_MODE ? "RX" : "TX", init_result);
     LOGF("--------------------------\r\n");
     LOGF("\r\n");
-    // Error_Handler_Code(init_result);
+    Error_Handler_Code(init_result);
   }
 
   //-----------------------------------------------------------------------------//
@@ -364,14 +364,18 @@ int main(void) {
 
   while (1) {
 
-    // // 2) Debounce button
-    // while (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_RESET) {
-    // }
-    // __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_7);
+    // 1) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7)
+    LOGF("Entering STOP mode...\r\n");
+    EnterStopMode();
+
+    // 2) Debounce button
+    while (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_RESET) {
+    }
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_7);
 
     // For testing without button: just delay for a few seconds to simulate
     // sleep
-    HAL_Delay(2000);
+    // HAL_Delay(2000);
 
     uint32_t wake_tick = HAL_GetTick();
 
@@ -496,7 +500,7 @@ int main(void) {
     } else {
       // Send transmission over radio
       LOGF("Starting transmission over radio...\r\n");
-      // LED_BlinkStatusCode(STATUS_CODE_STARTING_TRANSMISSION);
+      LED_BlinkStatusCode(STATUS_CODE_STARTING_TRANSMISSION);
       start_TX();
     }
 
@@ -543,10 +547,6 @@ int main(void) {
 
       RTC_SetWakeupTimer(sleep_seconds);
     }
-
-    // 1) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7)
-    LOGF("Entering STOP mode...\r\n");
-    EnterStopMode();
 
     /* USER CODE END WHILE */
 
@@ -978,6 +978,8 @@ static void MX_GPIO_Init(void) {
   GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+  HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
+  HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 
   /* USER CODE BEGIN MX_GPIO_Init_2 */
 
@@ -1360,7 +1362,7 @@ static void TX_Start(void) {
 
   if (st != HAL_OK) {
     LOGF("  HAL_DAC_Start_DMA error: %d\r\n", st);
-    // Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
+    Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
   } else {
     LOGF("  HAL_DAC_Start_DMA OK\r\n");
   }
@@ -1374,7 +1376,7 @@ static void TX_Start(void) {
 
   if (st != HAL_OK) {
     LOGF("  HAL_TIM_Base_Start error: %d\r\n", st);
-    // Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
+    Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
   } else {
     LOGF("  HAL_TIM_Base_Start OK\r\n");
   }

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -141,7 +141,7 @@ void transmit_bytes(void) {
   CC1101_WriteBurstReg(0x3F, pkt, sizeof(pkt), &status);
   if (status != 0x0F) {
     LOGF("Error writing to TX FIFO, status: 0x%02X\r\n", status);
-    // Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
+    Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
     return;
   }
 

--- a/STM32/Core/Src/stm32g4xx_it.c
+++ b/STM32/Core/Src/stm32g4xx_it.c
@@ -244,4 +244,13 @@ void TIM6_DAC_IRQHandler(void)
 }
 
 /* USER CODE BEGIN 1 */
+
+/**
+  * @brief This function handles EXTI line[9:5] interrupts.
+  */
+void EXTI9_5_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7);
+}
+
 /* USER CODE END 1 */


### PR DESCRIPTION
This pull request primarily improves error handling and power management in the STM32 firmware by enabling previously commented-out error handler calls, refining the STOP mode entry logic, and adding proper external interrupt (EXTI) support for GPIO pin 7. These changes enhance system robustness and prepare the code for reliable low-power operation and wakeup via GPIO interrupts.

**Error Handling Improvements:**
- Enabled calls to `Error_Handler_Code` in multiple locations, ensuring the system properly responds to low battery, LUT allocation failure, radio initialization errors, and transmission errors in both `main.c`, `battery.c`, and `radio.c` (`Error_Handler_Code` was previously commented out). [[1]](diffhunk://#diff-328f0680764cc3e9c16123202ae171be2a0cedfe528152541a82cadc31043834L34-R34) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L315-R315) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L343-R347) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1363-R1365) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1377-R1379) [[6]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baL144-R144)

**Power Management and Wakeup Logic:**
- Refined the main loop to actively enter STOP mode and wait for wakeup via EXTI (GPIOB Pin 7), including button debounce logic. The code now logs STOP mode entry and clears the EXTI interrupt after wakeup. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L367-R378) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L547-L550)
- Added and enabled the `EXTI9_5_IRQHandler` interrupt handler for GPIO pin 7, including NVIC priority setup and enabling the interrupt in GPIO initialization. This allows the MCU to wake from STOP mode on a GPIO event. [[1]](diffhunk://#diff-20652c247a474f1d13fcba990876d83f2e236b1a89974091adf78e12fcef4eebR247-R255) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R981-R982)

**Status Indication:**
- Enabled LED status code blinks for system boot and transmission start, improving feedback for system state transitions. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L294-R294) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L499-R503)

**Logging Improvements:**
- Improved radio initialization error logs to display whether the system is in RX or TX mode, aiding debugging.