### PR TITLE
Enhance TX mode configuration and improve STOP mode handling

### DIFF
--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -368,6 +368,9 @@ int main(void) {
 
   if (RX_MODE) {
     Relay_SetBypassMode();
+  } else {
+    LOGF("Configuring for TX mode\r\n");
+    RTC_SetWakeupTimer(60);
   }
 
   //-----------------------------------------------------------------------------//
@@ -378,6 +381,10 @@ int main(void) {
   LOGF("\r\n");
 
   while (1) {
+    // 3) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7)
+    LOGF("Entering STOP mode...\r\n");
+    EnterStopMode();
+
     // 1) Check battery voltage and go back to sleep if low
     Battery_IsLow(&hadc1);
 
@@ -546,10 +553,6 @@ int main(void) {
 
       RTC_SetWakeupTimer(sleep_seconds);
     }
-
-    // 3) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7)
-    LOGF("Entering STOP mode...\r\n");
-    EnterStopMode();
 
     /* USER CODE END WHILE */
 
@@ -1013,8 +1016,15 @@ void EnterStopMode(void) {
   HAL_NVIC_ClearPendingIRQ(EXTI9_5_IRQn);
   __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hrtc, RTC_FLAG_WUTF);
   PWR->SCR = PWR_SCR_CWUF;
+
   __DSB();
   __ISB();
+
+  if (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_SET) {
+    HAL_ResumeTick();
+    SystemClock_Config();
+    return;
+  }
 
   HAL_PWREx_EnterSTOP1Mode(PWR_STOPENTRY_WFI);
 


### PR DESCRIPTION
This pull request updates the power management and wakeup logic in `main.c` to improve STOP mode handling and system behavior in TX mode. The main changes are the relocation of STOP mode entry, improved logging, and additional checks before entering low power mode.

**Power management and STOP mode handling:**
* Moved the call to `EnterStopMode()` and its associated logging from the end of the main loop to the start, ensuring STOP mode is entered at the correct point in the loop (`main.c`) [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R384-R387) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L550-L553).
* Added a check in `EnterStopMode()` to skip STOP mode entry if `GPIOB Pin 7` is already set, immediately resuming the system clock instead of sleeping unnecessarily (`main.c`).

**TX mode configuration and logging:**
* Added logging and a wakeup timer setup for TX mode, improving visibility and behavior when not in RX mode (`main.c`).

These changes help ensure the system enters STOP mode only when appropriate and provides clearer runtime information for debugging and operation.