### PR TITLE
132 wake on radio

### DIFF
--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -4,24 +4,36 @@ typedef struct {
   uint8_t value;
 } ism_reg_t;
 
-// Configuration arrays for RX mode in 433MHz band
 static const ism_reg_t cc1101_cfg_rx[] = {
-    {0x02, 0x07}, // IOCFG0: GDO0 asserts on sync, deassert end/FIFO overflow
-    {0x04, 0x04}, // Set sync word (SYNC1)
-    {0x05, 0x05}, // Set sync word (SYNC0)
-    {0x09, 0xEB}, // Set ADDR = EB
-    {0x07, 0x05}, // Enable address check
+    {0x02, 0x06}, // IOCFG0: GDO0 asserts on sync, deasserts end-of-packet
+    {0x04, 0x04}, // SYNC1
+    {0x05, 0x05}, // SYNC0
+    {0x09, 0xEB}, // ADDR = 0xEB
+    {0x07, 0x05}, // PKTCTRL1: address check enabled
     {0x0D, 0x10}, // FREQ2
     {0x0E, 0xA7}, // FREQ1
     {0x0F, 0x62}, // FREQ0
+    {0x10, 0x85}, // MDMCFG4: BW=203kHz, DRATE_E=5  -> 1200 bps
+    {0x11, 0x83}, // MDMCFG3: DRATE_M=131           -> 1200 bps
+    {0x13, 0xF2}, // MDMCFG1: NUM_PREAMBLE=24 bytes, FEC off
+    {0x17,
+     0x07}, // MCSM2: RX_TIME=7 (stay in RX until packet done after WOR wake)
+    {0x18,
+     0x18}, // MCSM0: FS_AUTOCAL=01 (calibrate on each IDLE->RX transition)
+    {0x1E, 0x43}, // WOREVT1: EVENT0 high byte  \  0x43CC = 17356 counts
+    {0x1F, 0xCC}, // WOREVT0: EVENT0 low byte    /  -> ~500 ms wake interval
+    {0x20, 0x78}, // WORCTRL: RC_PD=0, EVENT1=7 (~1.8ms CS window), RC_CAL=1,
+                  // WOR_RES=0
 };
 
-// Configuration arrays for TX mode in 433MHz band
 static const ism_reg_t cc1101_cfg_tx[] = {
-    {0x02, 0x07}, // IOCFG0: GDO0 asserts on sync, deassert end/FIFO overflow
-    {0x04, 0x04}, // Set sync word (SYNC1)
-    {0x05, 0x05}, // Set sync word (SYNC0)
+    {0x02, 0x06}, // IOCFG0
+    {0x04, 0x04}, // SYNC1
+    {0x05, 0x05}, // SYNC0
     {0x0D, 0x10}, // FREQ2
     {0x0E, 0xA7}, // FREQ1
     {0x0F, 0x62}, // FREQ0
+    {0x10, 0x85}, // MDMCFG4: 1200 bps (must match RX)
+    {0x11, 0x83}, // MDMCFG3: 1200 bps (must match RX)
+    {0x13, 0xF2}, // MDMCFG1: 24-byte preamble (160 ms at 1200 bps)
 };

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -5,35 +5,39 @@ typedef struct {
 } ism_reg_t;
 
 static const ism_reg_t cc1101_cfg_rx[] = {
-    {0x02, 0x06}, // IOCFG0: GDO0 asserts on sync, deasserts end-of-packet
-    {0x04, 0x04}, // SYNC1
-    {0x05, 0x05}, // SYNC0
-    {0x09, 0xEB}, // ADDR = 0xEB
-    {0x07, 0x05}, // PKTCTRL1: address check enabled
-    {0x0D, 0x10}, // FREQ2
-    {0x0E, 0xA7}, // FREQ1
-    {0x0F, 0x62}, // FREQ0
-    {0x10, 0x85}, // MDMCFG4: BW=203kHz, DRATE_E=5  -> 1200 bps
-    {0x11, 0x83}, // MDMCFG3: DRATE_M=131           -> 1200 bps
-    {0x13, 0xF2}, // MDMCFG1: NUM_PREAMBLE=24 bytes, FEC off
+    {0x02, 0x06}, // IOCFG0: GDO0 asserts on sync word, deasserts end-of-packet
+    {0x04, 0x04}, // SYNC1: sync word high byte = 0x04
+    {0x05, 0x05}, // SYNC0: sync word low byte = 0x05
+    {0x06, 0x3D}, // PKTLEN: max packet length = 61 bytes
+    {0x07, 0x05}, // PKTCTRL1: address check enabled, no status bytes appended
+    {0x08, 0x01}, // PKTCTRL0: variable length, no CRC, no data whitening
+    {0x09, 0xEB}, // ADDR: device address = 0xEB
+    {0x0D, 0x10}, // FREQ2: carrier frequency high byte  \
+    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte    > 433 MHz
+    {0x0F, 0x62}, // FREQ0: carrier frequency low byte   /
+    {0x10, 0x85}, // MDMCFG4: channel BW=203kHz, DRATE_E=5 -> 1200 bps
+    {0x11, 0x83}, // MDMCFG3: DRATE_M=131 -> 1200 bps
+    {0x13, 0xF2}, // MDMCFG1: 24-byte preamble, FEC disabled
     {0x17,
-     0x07}, // MCSM2: RX_TIME=7 (stay in RX until packet done after WOR wake)
-    {0x18,
-     0x18}, // MCSM0: FS_AUTOCAL=01 (calibrate on each IDLE->RX transition)
-    {0x1E, 0x43}, // WOREVT1: EVENT0 high byte  \  0x43CC = 17356 counts
-    {0x1F, 0xCC}, // WOREVT0: EVENT0 low byte    /  -> ~500 ms wake interval
+     0x07}, // MCSM2: RX_TIME=7, stay in RX until packet done after WOR wake
+    {0x18, 0x18}, // MCSM0: FS_AUTOCAL=01, calibrate on IDLE->RX transition
+    {0x1E, 0x43}, // WOREVT1: EVENT0 high byte \  0x43CC = 17356 counts
+    {0x1F, 0xCC}, // WOREVT0: EVENT0 low byte   > ~500 ms WOR wake interval
     {0x20, 0x78}, // WORCTRL: RC_PD=0, EVENT1=7 (~1.8ms CS window), RC_CAL=1,
                   // WOR_RES=0
 };
 
 static const ism_reg_t cc1101_cfg_tx[] = {
-    {0x02, 0x06}, // IOCFG0
-    {0x04, 0x04}, // SYNC1
-    {0x05, 0x05}, // SYNC0
-    {0x0D, 0x10}, // FREQ2
-    {0x0E, 0xA7}, // FREQ1
-    {0x0F, 0x62}, // FREQ0
-    {0x10, 0x85}, // MDMCFG4: 1200 bps (must match RX)
-    {0x11, 0x83}, // MDMCFG3: 1200 bps (must match RX)
-    {0x13, 0xF2}, // MDMCFG1: 24-byte preamble (160 ms at 1200 bps)
+    {0x02, 0x06}, // IOCFG0: GDO0 asserts on sync word, deasserts end-of-packet
+    {0x04, 0x04}, // SYNC1: sync word high byte = 0x04
+    {0x05, 0x05}, // SYNC0: sync word low byte = 0x05
+    {0x06, 0x3D}, // PKTLEN: max packet length = 61 bytes
+    {0x08, 0x01}, // PKTCTRL0: variable length, no CRC, no data whitening
+    {0x0D, 0x10}, // FREQ2: carrier frequency high byte  \
+    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte    > 433 MHz
+    {0x0F, 0x62}, // FREQ0: carrier frequency low byte   /
+    {0x10, 0x85}, // MDMCFG4: channel BW=203kHz, DRATE_E=5 -> 1200 bps
+    {0x11, 0x83}, // MDMCFG3: DRATE_M=131 -> 1200 bps
+    {0x13,
+     0xF2}, // MDMCFG1: 24-byte preamble (160 ms at 1200 bps), FEC disabled
 };

--- a/STM32/Core/Inc/radio.h
+++ b/STM32/Core/Inc/radio.h
@@ -26,9 +26,7 @@ int8_t Radio_InitTXMode(void);
 int8_t Radio_Init(bool RX);
 
 /**
- * @brief Create the payload string to transmit based on user config and RTC
- * time.
- * @return Pointer to a static buffer containing the payload string.
+ * @brief Transmit payload 3 times back-to-back for WOR preamble coverage.
  */
 void Radio_Transmit(void);
 
@@ -36,6 +34,11 @@ void Radio_Transmit(void);
  * @brief Read RX FIFO (RXBYTES), dump bytes to printf, then SIDLE + SFRX + SRX.
  */
 int Radio_Receive(uint8_t *out, size_t out_max);
+
+/**
+ * @brief Enter WOR mode (after configuring WOR settings in init).
+ */
+void Radio_EnterWOR(void);
 
 /**
  * @brief Start RX loop: continuously read RX FIFO and print.

--- a/STM32/Core/Src/ds3231.c
+++ b/STM32/Core/Src/ds3231.c
@@ -19,7 +19,7 @@ void DS3231_Init(void) {
 
   // Read current seconds register
   if (HAL_I2C_Mem_Read(&hi2c2, DS3231_ADDR, 0x00, I2C_MEMADD_SIZE_8BIT, &sec, 1,
-                       HAL_MAX_DELAY) != HAL_OK) {
+                       1000) != HAL_OK) {
     return;
   }
 
@@ -28,7 +28,7 @@ void DS3231_Init(void) {
 
   // Write it back
   if (HAL_I2C_Mem_Write(&hi2c2, DS3231_ADDR, 0x00, I2C_MEMADD_SIZE_8BIT, &sec,
-                        1, HAL_MAX_DELAY) != HAL_OK) {
+                        1, 1000) != HAL_OK) {
     return;
   }
   return;
@@ -71,16 +71,17 @@ void DS3231_SetTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t dow,
   set_time[6] = DS3231_DecToBcd(year % 100);  // Year (00–99)
 
   HAL_I2C_Mem_Write(&hi2c2, DS3231_ADDR, 0x00, I2C_MEMADD_SIZE_8BIT, set_time,
-                    7, HAL_MAX_DELAY);
+                    7, 1000);
   LOGF("RTC Time Set: %02d:%02d:%02d %02d/%02d/%04d\r\n", hour, min, sec, dom,
        month, year);
 }
 
 // Read time/date from DS3231
 void DS3231_GetTime(rtc_time_t *time) {
+  LOGF("Reading time from DS3231...\r\n");
   uint8_t get_time[7];
   if (HAL_I2C_Mem_Read(&hi2c2, DS3231_ADDR, 0x00, I2C_MEMADD_SIZE_8BIT,
-                       get_time, 7, HAL_MAX_DELAY) != HAL_OK) {
+                       get_time, 7, 1000) != HAL_OK) {
     time->seconds = 0;
     time->minutes = 0;
     time->hours = 0;
@@ -88,6 +89,8 @@ void DS3231_GetTime(rtc_time_t *time) {
     time->date = 0;
     time->month = 0;
     time->year = 2000;
+
+    LOGF("Failed to read time from DS3231\r\n");
     return;
   }
 
@@ -109,8 +112,9 @@ void DS3231_GetTime(rtc_time_t *time) {
 void DS3231_ReadTemperature(int8_t *temperature) {
   uint8_t msb;
   if (HAL_I2C_Mem_Read(&hi2c2, DS3231_ADDR, 0x11, I2C_MEMADD_SIZE_8BIT, &msb, 1,
-                       HAL_MAX_DELAY) != HAL_OK) {
+                       1000) != HAL_OK) {
     *temperature = 0;
+    LOGF("Failed to read temperature from DS3231\r\n");
     return;
   }
 

--- a/STM32/Core/Src/ds3231.c
+++ b/STM32/Core/Src/ds3231.c
@@ -38,7 +38,15 @@ void DS3231_Init(void) {
 void DS3231_PowerOn(void) {
   HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_SET);
   LOGF("DS3231 Power ON\r\n");
-  HAL_Delay(5);
+
+  uint32_t start = HAL_GetTick();
+  while (HAL_GetTick() - start < 100) {
+    if (HAL_I2C_IsDeviceReady(&hi2c2, DS3231_ADDR, 1, 10) == HAL_OK) {
+      LOGF("DS3231 ready after %lu ms\r\n", HAL_GetTick() - start);
+      return;
+    }
+  }
+  LOGF("DS3231 not responding after 100ms\r\n");
 }
 
 // Power off the DS3231 by setting the control pin low
@@ -80,8 +88,12 @@ void DS3231_SetTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t dow,
 void DS3231_GetTime(rtc_time_t *time) {
   LOGF("Reading time from DS3231...\r\n");
   uint8_t get_time[7];
-  if (HAL_I2C_Mem_Read(&hi2c2, DS3231_ADDR, 0x00, I2C_MEMADD_SIZE_8BIT,
-                       get_time, 7, 1000) != HAL_OK) {
+  HAL_StatusTypeDef ret = HAL_I2C_Mem_Read(
+      &hi2c2, DS3231_ADDR, 0x00, I2C_MEMADD_SIZE_8BIT, get_time, 7, 1000);
+  if (ret != HAL_OK) {
+    LOGF("Failed to read time from DS3231, HAL error=%d, I2C error=0x%lX\r\n",
+         ret, HAL_I2C_GetError(&hi2c2));
+
     time->seconds = 0;
     time->minutes = 0;
     time->hours = 0;
@@ -90,7 +102,6 @@ void DS3231_GetTime(rtc_time_t *time) {
     time->month = 0;
     time->year = 2000;
 
-    LOGF("Failed to read time from DS3231\r\n");
     return;
   }
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -95,6 +95,8 @@
 #define OUTPUT_SEGMENT 500
 #define BUFFER_SIZE (OUTPUT_SEGMENT * 5)
 
+#define SYNC_DELAY_MS 3000
+
 /* USER CODE END PD */
 
 /* Private macro -------------------------------------------------------------*/
@@ -167,6 +169,8 @@ volatile status_code_t g_error_code = STATUS_CODE_OK;
 
 extern volatile uint8_t cdc_rx_buf[64];
 extern volatile uint8_t cdc_rx_len;
+
+uint32_t wake_up_tick = 0;
 
 /* USER CODE END PV */
 
@@ -388,10 +392,12 @@ int main(void) {
     LOGF("Entering STOP mode...\r\n");
     EnterStopMode();
 
+    uint32_t wake_time = HAL_GetTick();
+    LOGF("Woke up after %lu ms\r\n", wake_time - wake_up_tick);
+
     // 1) Check battery voltage and go back to sleep if low
     Battery_IsLow(&hadc1);
 
-    uint32_t wake_tick = HAL_GetTick();
     LOGF("Woke up!\r\n");
 
     // 2) Get current time from RTC
@@ -475,9 +481,20 @@ int main(void) {
       LOGF("\r\n");
       calculate_active_duration_ms(BITSTREAM_LENGTH);
       uint32_t total_ms = (uint32_t)(total_time * 1000.0f);
-      LOGF("Calculated active duration for response: %lu ms\r\n",
-           (unsigned long)total_ms);
-      LOGF("\r\n");
+
+      uint32_t preparation_time_ms = HAL_GetTick() - wake_up_tick;
+      LOGF("Preparation time: %lu ms\r\n", (unsigned long)preparation_time_ms);
+
+      // Wait until all units reach the same point in time
+      uint32_t target_tick = wake_up_tick + SYNC_DELAY_MS;
+      int32_t wait_ms = (int32_t)(target_tick - HAL_GetTick());
+      if (wait_ms > 0) {
+        LOGF("Sync wait: %ld ms\r\n", wait_ms);
+        HAL_Delay((uint32_t)wait_ms);
+      } else {
+        LOGF("WARNING: preparation exceeded SYNC_DELAY_MS by %ld ms\r\n",
+             -wait_ms);
+      }
 
       // Send transmission over audio
       LOGF("Starting transmission of response over audio...\r\n");
@@ -512,6 +529,8 @@ int main(void) {
       // Stop transmission and go back to sleep
       stop_audio_transmission();
 
+      Radio_EnterWOR(); // ← add this
+
     } else {
       // Send transmission over radio
       LOGF("Starting transmission over radio...\r\n");
@@ -526,7 +545,7 @@ int main(void) {
         target_interval_s = INTERVAL_BETWEEN_REPEATS_MINUTES * 60;
       }
 
-      uint32_t elapsed_ms = HAL_GetTick() - wake_tick;
+      uint32_t elapsed_ms = HAL_GetTick() - wake_up_tick;
       uint32_t elapsed_s = elapsed_ms / 1000;
 
       uint32_t sleep_seconds;
@@ -996,57 +1015,54 @@ static void MX_GPIO_Init(void) {
 /* USER CODE BEGIN 4 */
 
 void EnterStopMode(void) {
-
   __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_7);
   HAL_NVIC_ClearPendingIRQ(EXTI9_5_IRQn);
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hrtc, RTC_FLAG_WUTF);
   PWR->SCR = PWR_SCR_CWUF;
+
   DBGMCU->CR &=
       ~(DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_SLEEP | DBGMCU_CR_DBG_STANDBY);
 
-  HAL_SuspendTick();
-
   if (RX_MODE) {
-    // RX: wake on PB7 only — disable RTC wakeup timer
     HAL_RTCEx_DeactivateWakeUpTimer(&hrtc);
     HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
   } else {
-    // TX: wake on RTC only — disable PB7
     HAL_NVIC_DisableIRQ(EXTI9_5_IRQn);
     HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
   }
 
-  __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_7);
-  HAL_NVIC_ClearPendingIRQ(EXTI9_5_IRQn);
-  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hrtc, RTC_FLAG_WUTF);
-  PWR->SCR = PWR_SCR_CWUF;
-
   __DSB();
   __ISB();
-
-  if (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_SET) {
-    HAL_ResumeTick();
-    SystemClock_Config();
-    MX_USART2_UART_Init();
-    MX_USB_Device_Init(); // add this
-    HAL_Delay(500);
-    return;
-  }
-
+  HAL_SuspendTick();
   HAL_PWREx_EnterSTOP1Mode(PWR_STOPENTRY_WFI);
 
-  // Woke up here
   SystemClock_Config();
   HAL_ResumeTick();
+  wake_up_tick = HAL_GetTick();
+  MX_I2C2_Init();
   MX_USART2_UART_Init();
-  MX_USB_Device_Init(); // add this
-  HAL_Delay(500);       // wait for host to re-enumerate
+  MX_USB_Device_Init();
+  HAL_Delay(10);
 
-  // Restore both interrupt sources after wakeup
+  // RX only: wait for GDO0 to deassert after wakeup
+  if (RX_MODE) {
+    uint32_t settle = HAL_GetTick();
+    while (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_SET &&
+           HAL_GetTick() - settle < 5) {
+    }
+  }
+
   HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
-  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hrtc, RTC_FLAG_WUTF);
+  if (RX_MODE) {
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_7);
+    HAL_NVIC_ClearPendingIRQ(EXTI9_5_IRQn);
+  } else {
+    __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hrtc, RTC_FLAG_WUTF);
+  }
   __HAL_PWR_CLEAR_FLAG(PWR_FLAG_WU);
   PWR->SCR = PWR_SCR_CWUF;
 }
+
 void StartActiveWindowMs(uint32_t ms) {
   active_done = 0;
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -505,6 +505,7 @@ int main(void) {
       } else {
         LOGF("Using speaker transmission\r\n");
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
+        HAL_Delay(50);
       }
       LOGF("\r\n");
 
@@ -971,18 +972,19 @@ static void MX_GPIO_Init(void) {
   __HAL_RCC_GPIOB_CLK_ENABLE();
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(
-      GPIOA, GPIO_PIN_1 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 | GPIO_PIN_10,
-      GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(GPIOA,
+                    GPIO_PIN_1 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 |
+                        GPIO_PIN_10 | GPIO_PIN_15,
+                    GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
   HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0 | GPIO_PIN_3 | GPIO_PIN_4 | GPIO_PIN_6,
                     GPIO_PIN_RESET);
 
   /*Configure GPIO pins : PA1 PA5 PA6 PA7
-                           PA10 */
-  GPIO_InitStruct.Pin =
-      GPIO_PIN_1 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 | GPIO_PIN_10;
+                           PA10 PA15 */
+  GPIO_InitStruct.Pin = GPIO_PIN_1 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 |
+                        GPIO_PIN_10 | GPIO_PIN_15;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
@@ -1039,10 +1041,12 @@ void EnterStopMode(void) {
   SystemClock_Config();
   HAL_ResumeTick();
   wake_up_tick = HAL_GetTick();
+  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_SET);
   MX_I2C2_Init();
   MX_USART2_UART_Init();
   MX_USB_Device_Init();
   HAL_Delay(10);
+  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_RESET);
 
   // RX only: wait for GDO0 to deassert after wakeup
   if (RX_MODE) {

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -27,28 +27,12 @@ int8_t Radio_InitRXMode(void) {
     }
   }
 
-  CC1101_Strobe(0x33, &status); // Calibrate (SCAL) before TX
+  CC1101_Strobe(0x33, &status); // SCAL
+  CC1101_Strobe(0x38, &status); // SWOR
 
-  CC1101_Strobe(0x34, &status); // Go to RX state (SRX)
+  HAL_Delay(10);
 
-  // Wait for RX to be ready (check MARCSTATE)
-  while (1) {
-    uint8_t marcstate = 0;
-    CC1101_ReadReg(0xF5, &marcstate, &status); // MARCSTATE (status space)
-    if (marcstate == 0x0D) {
-      break; // RX
-    }
-
-    // Timeout after some time to avoid infinite loop (optional)
-    static uint32_t start_time = 0;
-    if (start_time == 0) {
-      start_time = HAL_GetTick();
-    } else if (HAL_GetTick() - start_time > 1000) { // 1 second timeout
-      LOGF("Timeout waiting for RX state, status: 0x%02X\r\n", status);
-      return STATUS_CODE_RADIO_MODE_ERROR;
-    }
-  }
-  LOGF("RX mode initialized.\r\n");
+  LOGF("RX WOR mode initialized (EVENT0~500ms, 1200bps).\r\n");
   return 0;
 }
 
@@ -117,7 +101,7 @@ int8_t Radio_Init(bool RX) {
   return STATUS_CODE_RADIO_INIT_FAIL;
 }
 
-char *Radio_BuildPayload(void) {
+char *Radio_BuildPayload(uint32_t offset_ms) {
   char temp_buf[256];
   size_t offset = 0;
 
@@ -142,49 +126,55 @@ char *Radio_BuildPayload(void) {
                  now.seconds, now.day, now.date, now.month, now.year);
   }
 
+  offset += snprintf(temp_buf + offset, sizeof(temp_buf) - offset, "/OFS%lu",
+                     (unsigned long)offset_ms);
+
   return strdup(temp_buf);
 }
 
 void Radio_Transmit(void) {
   LOGF("Starting radio transmission...\r\n");
   uint8_t status = 0;
+  uint32_t t0 = HAL_GetTick(); // Capture once before loop
 
-  const char *payload_str = Radio_BuildPayload();
-  size_t payload_len = strlen(payload_str);
+  for (int tx_repeat = 0; tx_repeat < 3; tx_repeat++) {
+    const char *payload_str = Radio_BuildPayload(HAL_GetTick() - t0);
+    size_t payload_len = strlen(payload_str);
 
-  LOGF("Transmitting payload: %s\r\n", payload_str);
-  LOGF("Payload in hex: ");
-  for (size_t i = 0; i < payload_len; i++) {
-    LOGF("%02X ", (unsigned char)payload_str[i]);
-  }
-  LOGF("\r\n");
-  uint8_t pkt[2 + payload_len]; // length byte + payload
-  pkt[0] = payload_len + 1;     // length
-  pkt[1] = 0xEB;
-  memcpy(&pkt[2], payload_str, payload_len);
+    LOGF("TX %d payload: %s\r\n", tx_repeat + 1, payload_str);
 
-  // Optional: flush TX FIFO before loading (good practice)
-  CC1101_Strobe(0x3B, &status); // SFTX :contentReference[oaicite:1]{index=1}
+    uint8_t pkt[2 + payload_len];
+    pkt[0] = payload_len + 1;
+    pkt[1] = 0xEB;
+    memcpy(&pkt[2], payload_str, payload_len);
 
-  // Burst write into TX FIFO
-  CC1101_WriteBurstReg(0x3F, pkt, sizeof(pkt), &status);
-  if (status != 0x0F) {
-    LOGF("Error writing to TX FIFO, status: 0x%02X\r\n", status);
-    Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
-    return;
-  }
+    CC1101_Strobe(0x3B, &status); // SFTX: flush TX FIFO
 
-  // Start TX
-  CC1101_Strobe(0x35, &status); // STX :contentReference[oaicite:3]{index=3}
-
-  // Wait for IDLE (mask state bits)
-  while (1) {
-    uint8_t marcstate = 0;
-    CC1101_ReadReg(0xF5, &marcstate, &status); // MARCSTATE (status space)
-    marcstate &= 0x1F;
-    if (marcstate == 0x01) {
-      break; // IDLE
+    CC1101_WriteBurstReg(0x3F, pkt, sizeof(pkt), &status);
+    if (status != 0x0F) {
+      LOGF("Error writing to TX FIFO, status: 0x%02X\r\n", status);
+      Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
+      return;
     }
+
+    CC1101_Strobe(0x35, &status); // STX
+
+    // Wait for IDLE with 2000 ms timeout
+    uint32_t tx_start = HAL_GetTick();
+    while (1) {
+      uint8_t marcstate = 0;
+      CC1101_ReadReg(0xF5, &marcstate, &status);
+      marcstate &= 0x1F;
+      if (marcstate == 0x01)
+        break; // IDLE — TX done
+      if (HAL_GetTick() - tx_start > 2000) {
+        LOGF("TX timeout on repeat %d, forcing IDLE.\r\n", tx_repeat + 1);
+        CC1101_Strobe(0x36, &status); // SIDLE
+        break;
+      }
+    }
+
+    free((void *)payload_str);
   }
 }
 
@@ -196,10 +186,8 @@ int Radio_Receive(uint8_t *out, size_t out_max_len) {
   CC1101_ReadReg(0xFB, &rxbytes, &status);
 
   if (rxbytes & 0x80) {
-    // FIFO overflow -> flush
-    CC1101_Strobe(0x36, &status); // SIDLE
-    CC1101_Strobe(0x3A, &status); // SFRX
-    CC1101_Strobe(0x34, &status); // SRX
+    LOGF("RX FIFO overflow, flushing and re-entering WOR.\r\n");
+    Radio_EnterWOR();
     return -1;
   }
 
@@ -224,10 +212,19 @@ int Radio_Receive(uint8_t *out, size_t out_max_len) {
   // }
   // LOGF("\r\n");
 
-  // Re-enter RX (and flush to be safe)
-  CC1101_Strobe(0x36, &status); // SIDLE
-  CC1101_Strobe(0x3A, &status); // SFRX
-  CC1101_Strobe(0x34, &status); // SRX
+  Radio_EnterWOR();
 
   return (int)n;
+}
+
+void Radio_EnterWOR(void) {
+  uint8_t status = 0;
+
+  CC1101_Strobe(0x36, &status); // SIDLE
+  HAL_Delay(1);
+  CC1101_Strobe(0x3A, &status); // SFRX
+  HAL_Delay(10);
+  CC1101_Strobe(0x38, &status); // SWOR
+
+  LOGF("Re-entered WOR mode.\r\n");
 }

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -184,18 +184,18 @@ void Radio_Transmit(void) {
 
 int Radio_Receive(uint8_t *out, size_t out_max_len) {
   uint8_t status = 0;
-  uint8_t rxbytes = 0;
-  uint8_t rxbytes_prev = 0;
 
-  // Wait for FIFO to stabilize (two consecutive identical reads)
+  // Wait for GDO0 to deassert — signals end of packet, FIFO is fully populated
   uint32_t start = HAL_GetTick();
-  do {
-    rxbytes_prev = rxbytes;
-    HAL_Delay(10); // was 2ms — increase to 10ms
-    CC1101_ReadReg(0xFB, &rxbytes, &status);
-    if (HAL_GetTick() - start > 200) // increase timeout too
+  while (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_SET) {
+    if (HAL_GetTick() - start > 500) {
+      LOGF("Timeout waiting for GDO0 to deassert\r\n");
       break;
-  } while (rxbytes != rxbytes_prev);
+    }
+  }
+
+  uint8_t rxbytes = 0;
+  CC1101_ReadReg(0xFB, &rxbytes, &status);
 
   if (rxbytes & 0x80) {
     LOGF("RX FIFO overflow, flushing and re-entering WOR.\r\n");
@@ -207,19 +207,16 @@ int Radio_Receive(uint8_t *out, size_t out_max_len) {
   if (n == 0)
     return 0;
 
-  // Don't read more than the user buffer
   if (n > out_max_len)
     n = (uint8_t)out_max_len;
 
-  // Clear the output buffer before writing new data
   memset(out, 0, out_max_len);
   out[0] = '\0';
 
-  CC1101_ReadBurstReg(0xFF, out, n, &status); // RX FIFO burst read
+  CC1101_ReadBurstReg(0xFF, out, n, &status);
   LOGF("RXBYTES n=%d, out[0]=0x%02X(len), out[1]=0x%02X(addr), last=0x%02X\r\n",
        n, out[0], out[1], out[n - 1]);
 
-  // Print received bytes in hex
   LOGF("Received %d bytes: ", n);
   for (size_t i = 0; i < n; i++) {
     LOGF("%02X ", out[i]);

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <stm32g4xx_hal.h>
 #include <string.h>
 #include <sys/_intsup.h>
@@ -109,21 +110,21 @@ char *Radio_BuildPayload(uint32_t offset_ms) {
     offset += snprintf(temp_buf + offset, sizeof(temp_buf) - offset, "/STR%s",
                        USER_STRING);
   }
+
   if (INCLUDE_TIME) {
     rtc_time_t now;
     DS3231_PowerOn();
     DS3231_GetTime(&now);
     DS3231_PowerOff();
 
-    if (now.year == 2000) {
-      LOGF("RTC time not set, don't include time in payload\r\n");
-      return strdup(temp_buf);
+    if (now.year != 2000) {
+      offset +=
+          snprintf(temp_buf + offset, sizeof(temp_buf) - offset,
+                   "/TIM%02d%02d%02d%02d%02d%02d%04d", now.hours, now.minutes,
+                   now.seconds, now.day, now.date, now.month, now.year);
+    } else {
+      LOGF("RTC time not set, skipping time field\r\n");
     }
-
-    offset +=
-        snprintf(temp_buf + offset, sizeof(temp_buf) - offset,
-                 "/TIM%02d%02d%02d%02d%02d%02d%04d;", now.hours, now.minutes,
-                 now.seconds, now.day, now.date, now.month, now.year);
   }
 
   offset += snprintf(temp_buf + offset, sizeof(temp_buf) - offset, "/OFS%lu",
@@ -147,6 +148,9 @@ void Radio_Transmit(void) {
     pkt[0] = payload_len + 1;
     pkt[1] = 0xEB;
     memcpy(&pkt[2], payload_str, payload_len);
+
+    LOGF("TX payload_len=%d pkt_size=%d\r\n", payload_len, 2 + payload_len);
+    LOGF("TX payload: %s\r\n", payload_str);
 
     CC1101_Strobe(0x3B, &status); // SFTX: flush TX FIFO
 
@@ -181,9 +185,17 @@ void Radio_Transmit(void) {
 int Radio_Receive(uint8_t *out, size_t out_max_len) {
   uint8_t status = 0;
   uint8_t rxbytes = 0;
+  uint8_t rxbytes_prev = 0;
 
-  // RXBYTES: bit7=overflow, bits[6:0]=num bytes
-  CC1101_ReadReg(0xFB, &rxbytes, &status);
+  // Wait for FIFO to stabilize (two consecutive identical reads)
+  uint32_t start = HAL_GetTick();
+  do {
+    rxbytes_prev = rxbytes;
+    HAL_Delay(10); // was 2ms — increase to 10ms
+    CC1101_ReadReg(0xFB, &rxbytes, &status);
+    if (HAL_GetTick() - start > 200) // increase timeout too
+      break;
+  } while (rxbytes != rxbytes_prev);
 
   if (rxbytes & 0x80) {
     LOGF("RX FIFO overflow, flushing and re-entering WOR.\r\n");
@@ -204,13 +216,15 @@ int Radio_Receive(uint8_t *out, size_t out_max_len) {
   out[0] = '\0';
 
   CC1101_ReadBurstReg(0xFF, out, n, &status); // RX FIFO burst read
+  LOGF("RXBYTES n=%d, out[0]=0x%02X(len), out[1]=0x%02X(addr), last=0x%02X\r\n",
+       n, out[0], out[1], out[n - 1]);
 
   // Print received bytes in hex
-  // LOGF("Received %d bytes: ", n);
-  // for (size_t i = 0; i < n; i++) {
-  //   LOGF("%02X ", out[i]);
-  // }
-  // LOGF("\r\n");
+  LOGF("Received %d bytes: ", n);
+  for (size_t i = 0; i < n; i++) {
+    LOGF("%02X ", out[i]);
+  }
+  LOGF("\r\n");
 
   Radio_EnterWOR();
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes for radio (CC1101) configuration, RTC (DS3231) communication robustness, and synchronization in the main application loop. The main themes are: more robust and synchronized radio operation (especially for wake-on-radio/WOR mode), improved error handling and logging for RTC I2C operations, and enhancements to GPIO and power management during sleep/wake cycles.

**Radio (CC1101) configuration and operation:**

* Overhauled RX and TX configuration arrays in `cc1101_config.h` to set up proper wake-on-radio (WOR) operation, including packet length, preamble, address check, and frequency settings. Added configuration for MDMCFG and WOR timing for low-power listening.
* Modified radio RX initialization to enter WOR mode (SWOR) instead of continuous RX, with a short delay for settling, and improved logging.
* Updated the radio transmit routine to send the payload three times back-to-back, each time including an offset timestamp. The payload builder now adds an offset field and only includes the time if the RTC is valid. [[1]](diffhunk://#diff-053abf93e5cd330ed130d2cd82a04d532208199a611a3894c2ef9dacd0799cd9L29-R29) [[2]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baL120-R240)
* Added `Radio_EnterWOR()` function to re-enter WOR mode after RX or on RX FIFO overflow, and ensured it is called appropriately in the receive path and main loop. [[1]](diffhunk://#diff-053abf93e5cd330ed130d2cd82a04d532208199a611a3894c2ef9dacd0799cd9R38-R42) [[2]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baL120-R240) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R533-R534)

**RTC (DS3231) communication improvements:**

* Replaced all `HAL_MAX_DELAY` I2C timeouts with a 1000 ms timeout for more robust error handling. [[1]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL22-R22) [[2]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL31-R31) [[3]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL74-R104) [[4]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL112-R128)
* Enhanced DS3231 power-on routine to poll for device readiness for up to 100 ms, logging the result, instead of using a fixed delay.
* Improved error reporting and logging when reading time or temperature from the DS3231. [[1]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL74-R104) [[2]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL112-R128)

**Synchronization and timing in main loop:**

* Added synchronization delay (`SYNC_DELAY_MS`) after waking up to align transmission times across devices, with logging for preparation time and warnings if exceeded. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R98-R99) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L478-R497)
* Tracked wake-up tick and used it for timing calculations throughout the main loop, improving accuracy of elapsed time and synchronization. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R173-R174) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R395-L394) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L529-R549)

**GPIO and power management:**

* Improved STOP mode entry/exit: added GPIO for power gating, ensured proper peripheral reinitialization, and handled wakeup sources and interrupts more robustly. Added PA15 as an output for power gating during wakeup. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L955-R987) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L999-R1069)

**Miscellaneous:**

* Minor code hygiene improvements, including adding missing includes and improved logging for received radio data. [[1]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baR12) [[2]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baL120-R240) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R508)
