### PR TITLE
135 add data field in message for message

### DIFF
--- a/Python/gui/scripts/build.py
+++ b/Python/gui/scripts/build.py
@@ -273,7 +273,8 @@ def send_time_sync(root, safe_log):
         return
 
     now = datetime.now()
-    time_str = f"T{now.hour:02d}:{now.minute:02d}:{now.second:02d} {now.weekday()} {now.day:02d}/{now.month:02d}/{now.year}\n"
+    dow = (now.weekday() + 1) % 7  # Convert Python's 0=Mon..6=Sun to 0=Sun..6=Sat
+    time_str = f"T{now.hour:02d}:{now.minute:02d}:{now.second:02d} {dow} {now.day:02d}/{now.month:02d}/{now.year}\n"
 
     try:
         with serial.Serial(port, 115200, timeout=2) as ser:

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -209,9 +209,10 @@ void read_buffer(void);
 
 void process_transmission(uint8_t *transmission, int *dBm_value);
 
-void create_payload_string(const char *user_str, int device_id,
+void create_payload_string(const char *user_string, int device_id,
                            const char *location, int8_t temperature,
-                           rtc_time_t time, uint8_t *output_str,
+                           rtc_time_t time_val, bool include_message_id,
+                           int8_t message_id, uint8_t *output_str,
                            size_t output_str_size);
 
 void create_string_from_received_data(const uint8_t *transmission,
@@ -578,7 +579,7 @@ int main(void) {
       create_payload_string(INCLUDE_USER_STRING ? USER_STRING : NULL,
                             INCLUDE_DEVICE_ID ? DEVICE_ID : -1,
                             INCLUDE_LOCATION ? LOCATION : NULL,
-                            INCLUDE_TEMPERATURE ? temp_int : -1, now,
+                            INCLUDE_TEMPERATURE ? temp_int : -1, now, false, -1,
                             output_str, sizeof(output_str));
 
       size_t payload_len = strlen((char *)output_str);
@@ -1545,7 +1546,8 @@ void process_transmission(uint8_t *transmission, int *dBm_value) {
 
 void create_payload_string(const char *user_str, int device_id,
                            const char *location, int8_t temperature,
-                           rtc_time_t time_val, uint8_t *output_str,
+                           rtc_time_t time_val, bool INCLUDE_MESSAGE_ID,
+                           int8_t message_id, uint8_t *output_str,
                            size_t output_str_size) {
   if (!output_str || output_str_size == 0)
     return;
@@ -1556,6 +1558,15 @@ void create_payload_string(const char *user_str, int device_id,
   int n = 0;
 
   output_str[0] = '\0';
+
+  // Append MID if enabled
+  if (INCLUDE_MESSAGE_ID) {
+    n = snprintf(&temp_buf[offset], remaining, "/MID%02d", message_id);
+    if (n > 0 && (size_t)n < remaining) {
+      offset += (size_t)n;
+      remaining -= (size_t)n;
+    }
+  }
 
   if (INCLUDE_TIME) {
     n = snprintf(&temp_buf[offset], remaining,
@@ -1628,6 +1639,7 @@ void create_string_from_received_data(const uint8_t *transmission,
     return;
 
   // Defaults (fallback if missing in RX packet)
+  int mid = 0; // default MID if missing
   char user_string[64] = USER_STRING;
   int device_id = DEVICE_ID;
   char location[64] = LOCATION;
@@ -1640,6 +1652,14 @@ void create_string_from_received_data(const uint8_t *transmission,
 
   // Parse tokens
   for (char *tok = strtok(buf, "/"); tok != NULL; tok = strtok(NULL, "/")) {
+    if (strncmp(tok, "MID", 3) == 0) {
+      // MID is two digits
+      char mid_buf[3] = {0};
+      mid_buf[0] = tok[3];
+      mid_buf[1] = tok[4];
+      mid = atoi(mid_buf);
+    }
+
     if (strncmp(tok, "TIM", 3) == 0) {
       const char *p = tok + 3;
 
@@ -1688,7 +1708,7 @@ void create_string_from_received_data(const uint8_t *transmission,
   }
 
   create_payload_string(user_string, device_id, location, temperature, time_val,
-                        output_str, output_str_size);
+                        true, mid, output_str, output_str_size);
 }
 
 static int init_luts_from_freqpair(void) {

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -14,6 +14,8 @@
 #include <string.h>
 #include <sys/_intsup.h>
 
+int8_t message_id = 0;
+
 int8_t Radio_InitRXMode(void) {
   LOGF("Initializing radio in RX mode...\r\n");
   uint8_t status = 0;
@@ -50,7 +52,11 @@ int8_t Radio_InitTXMode(void) {
     }
   }
 
+  message_id = 0; // reset message ID counter on each init
+
   CC1101_Strobe(0x33, &status); // Calibrate (SCAL) before TX
+
+  LOGF("TX mode initialized (250kbps, no WOR).\r\n");
 
   return 0;
 }
@@ -89,14 +95,9 @@ int8_t Radio_Init(int8_t operation_mode) {
 
     if (operation_mode == 0) {
       return Radio_InitRXMode();
-    } else {
+    } else if (operation_mode == 1) {
       return Radio_InitTXMode();
     }
-
-    uint8_t st = 0;
-    CC1101_Strobe(0x36, &st); // SIDLE
-    CC1101_Strobe(0x3A, &st); // SFRX
-    CC1101_Strobe(0x3B, &st); // SFTX
   }
 
   return STATUS_CODE_RADIO_INIT_FAIL;
@@ -105,6 +106,13 @@ int8_t Radio_Init(int8_t operation_mode) {
 char *Radio_BuildPayload(uint32_t offset_ms) {
   char temp_buf[256];
   size_t offset = 0;
+
+  // Make sure message ID is always two digits for consistent parsing, and wrap
+  // around at 99
+  offset += snprintf(temp_buf + offset, sizeof(temp_buf) - offset, "/MID%02d",
+                     message_id);
+
+  message_id = (message_id + 1) % 100;
 
   if (INCLUDE_USER_STRING) {
     offset += snprintf(temp_buf + offset, sizeof(temp_buf) - offset, "/STR%s",
@@ -126,9 +134,6 @@ char *Radio_BuildPayload(uint32_t offset_ms) {
       LOGF("RTC time not set, skipping time field\r\n");
     }
   }
-
-  offset += snprintf(temp_buf + offset, sizeof(temp_buf) - offset, "/OFS%lu",
-                     (unsigned long)offset_ms);
 
   return strdup(temp_buf);
 }


### PR DESCRIPTION
This pull request introduces message ID (MID) tracking and parsing in the STM32 radio payload, improves time formatting for synchronization, and updates payload construction and parsing logic to support the new MID field. The changes ensure each transmitted payload includes a unique, incrementing message ID for easier tracking and debugging, and that this ID is parsed and preserved when reconstructing payloads from received data.

**Message ID (MID) support in radio payloads:**

* Added a global `message_id` variable to `radio.c`, initialized and incremented with each payload, wrapping at 99. The message ID is prepended to each outgoing payload as `/MIDxx` for consistent parsing. [[1]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baR17-R18) [[2]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baR55-R60) [[3]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baR110-R116)
* Reset `message_id` to 0 on each radio TX mode initialization to ensure predictable ID sequences after reinitialization.

**Payload construction and parsing updates:**

* Modified `create_payload_string` to accept MID parameters and include the `/MIDxx` field when specified. Updated all calls to this function to pass MID and control inclusion. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L212-R215) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L581-R582) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1548-R1550) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1562-R1570) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1691-R1711)
* Updated `create_string_from_received_data` to parse the MID field from incoming packets and preserve it in reconstructed payloads. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1642) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1655-R1662) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1691-R1711)

**Time synchronization improvement:**

* Fixed weekday calculation in `send_time_sync` (`build.py`) to convert Python's weekday (0=Mon) to the protocol's expected format (0=Sun).

These changes improve traceability of messages in the radio protocol and enhance payload handling robustness.