### PR TITLE
142 fix wakeup timer for tx

### DIFF
--- a/Python/gui/gui.py
+++ b/Python/gui/gui.py
@@ -586,7 +586,7 @@ class FlashToolApp(tk.Tk):
             fg=c["text"],
         ).grid(row=0, column=1, padx=(16, 6))
 
-        self.widgets["interval"] = tk.Spinbox(
+        self.widgets["base_interval"] = tk.Spinbox(
             row,
             from_=1,
             to=1440,
@@ -602,7 +602,7 @@ class FlashToolApp(tk.Tk):
             relief="solid",
             bd=1,
         )
-        self.widgets["interval"].grid(row=0, column=2, sticky="w")
+        self.widgets["base_interval"].grid(row=0, column=2, sticky="w")
 
         delay = self.section(left, "Initial Delay", 3)
         row = tk.Frame(delay, bg=c["surface"])
@@ -617,14 +617,14 @@ class FlashToolApp(tk.Tk):
             self.vars["use_start_minute"],
         )
 
-        self.widgets["start_minute"] = ttk.Spinbox(
+        self.widgets["base_start_minute"] = ttk.Spinbox(
             row,
             from_=0,
             to=59,
             width=6,
             textvariable=self.vars["start_minute"],
         )
-        self.widgets["start_minute"].grid(row=0, column=1, sticky="w")
+        self.widgets["base_start_minute"].grid(row=0, column=1, sticky="w")
 
     # -----------------------------------------------------
     # Receiver tab
@@ -653,10 +653,10 @@ class FlashToolApp(tk.Tk):
         self.widgets["receiver_user_string"] = self.entry_row(
             device, 0, "User String", self.vars["user_string"]
         )
-        self.widgets["device_id"] = self.entry_row(
+        self.widgets["receiver_device_id"] = self.entry_row(
             device, 1, "Device ID", self.vars["device_id"]
         )
-        self.widgets["location"] = self.entry_row(
+        self.widgets["receiver_location"] = self.entry_row(
             device, 2, "Location", self.vars["location"]
         )
 
@@ -692,24 +692,28 @@ class FlashToolApp(tk.Tk):
         row.grid(row=0, column=0, sticky="w")
 
         ttk.Label(row, text="Low (Hz):").grid(row=0, column=0, sticky="w")
-        self.widgets["frequency_low"] = ttk.Entry(
+        self.widgets["receiver_frequency_low"] = ttk.Entry(
             row, width=8, textvariable=self.vars["frequency_low"]
         )
-        self.widgets["frequency_low"].grid(row=0, column=1, padx=(8, 20), sticky="w")
+        self.widgets["receiver_frequency_low"].grid(
+            row=0, column=1, padx=(8, 20), sticky="w"
+        )
 
         ttk.Label(row, text="High (Hz):").grid(row=0, column=2, sticky="w")
-        self.widgets["frequency_high"] = ttk.Entry(
+        self.widgets["receiver_frequency_high"] = ttk.Entry(
             row, width=8, textvariable=self.vars["frequency_high"]
         )
-        self.widgets["frequency_high"].grid(row=0, column=3, padx=(8, 0), sticky="w")
+        self.widgets["receiver_frequency_high"].grid(
+            row=0, column=3, padx=(8, 0), sticky="w"
+        )
 
         ToolTip(
-            self.widgets["frequency_low"],
+            self.widgets["receiver_frequency_low"],
             "Lower FSK frequency (Hz). Must be < High frequency.\nValid range: 2000-24000 Hz.",
             self.colors,
         )
         ToolTip(
-            self.widgets["frequency_high"],
+            self.widgets["receiver_frequency_high"],
             "Higher FSK frequency (Hz). Must be > Low frequency.\nValid range: 2000-24000 Hz.",
             self.colors,
         )
@@ -729,14 +733,16 @@ class FlashToolApp(tk.Tk):
 
         ttk.Label(row, text="Level:").grid(row=0, column=0, sticky="w")
 
-        self.widgets["attenuation"] = ttk.Spinbox(
+        self.widgets["receiver_attenuation"] = ttk.Spinbox(
             row,
             from_=0,
             to=100,
             width=6,
             textvariable=self.vars["attenuation"],
         )
-        self.widgets["attenuation"].grid(row=0, column=1, padx=(8, 4), sticky="w")
+        self.widgets["receiver_attenuation"].grid(
+            row=0, column=1, padx=(8, 4), sticky="w"
+        )
 
         ttk.Label(row, text="%").grid(row=0, column=2, sticky="w", padx=(0, 12))
 
@@ -761,17 +767,19 @@ class FlashToolApp(tk.Tk):
             self.vars["ecc_enabled"],
         ).grid(row=0, column=0, sticky="w")
 
-        self.widgets["ecc_level"] = ttk.Spinbox(
+        self.widgets["receiver_ecc_level"] = ttk.Spinbox(
             row,
             from_=0,
             to=100,
             width=6,
             textvariable=self.vars["ecc_level"],
         )
-        self.widgets["ecc_level"].grid(row=0, column=1, padx=(8, 0), sticky="w")
+        self.widgets["receiver_ecc_level"].grid(
+            row=0, column=1, padx=(8, 0), sticky="w"
+        )
         ToolTip(
-            self.widgets["ecc_level"],
-            "Number of Reed-Solomon error-correction symbols (0–100).\nHigher = more robust, but longer transmissions.",
+            self.widgets["receiver_ecc_level"],
+            "Number of Reed-Solomon error-correction symbols (0-100).\nHigher = more robust, but longer transmissions.",
             self.colors,
         )
 
@@ -804,10 +812,10 @@ class FlashToolApp(tk.Tk):
         self.widgets["standalone_user_string"] = self.entry_row(
             device, 0, "User String", self.vars["user_string"]
         )
-        self.widgets["device_id"] = self.entry_row(
+        self.widgets["standalone_device_id"] = self.entry_row(
             device, 1, "Device ID", self.vars["device_id"]
         )
-        self.widgets["location"] = self.entry_row(
+        self.widgets["standalone_location"] = self.entry_row(
             device, 2, "Location", self.vars["location"]
         )
 
@@ -834,7 +842,7 @@ class FlashToolApp(tk.Tk):
             row=0, column=1, padx=(16, 6)
         )
 
-        self.widgets["sa_interval"] = tk.Spinbox(
+        self.widgets["standalone_interval"] = tk.Spinbox(
             irow,
             from_=1,
             to=1440,
@@ -850,7 +858,7 @@ class FlashToolApp(tk.Tk):
             relief="solid",
             bd=1,
         )
-        self.widgets["sa_interval"].grid(row=0, column=2, sticky="w")
+        self.widgets["standalone_interval"].grid(row=0, column=2, sticky="w")
 
         # Initial Delay  (from Base)
         delay = self.section(left, "Initial Delay", 3)
@@ -859,10 +867,10 @@ class FlashToolApp(tk.Tk):
         drow.grid_columnconfigure(0, weight=1)
 
         self.checkbox(drow, 0, 0, "Use Starting Minute", self.vars["use_start_minute"])
-        self.widgets["sa_start_minute"] = ttk.Spinbox(
+        self.widgets["standalone_start_minute"] = ttk.Spinbox(
             drow, from_=0, to=59, width=6, textvariable=self.vars["start_minute"]
         )
-        self.widgets["sa_start_minute"].grid(row=0, column=1, sticky="w")
+        self.widgets["standalone_start_minute"].grid(row=0, column=1, sticky="w")
 
         # Transmission settings
         tx = self.section(right, "Transmission Settings", 0)
@@ -885,24 +893,28 @@ class FlashToolApp(tk.Tk):
         row.grid(row=0, column=0, sticky="w")
 
         ttk.Label(row, text="Low (Hz):").grid(row=0, column=0, sticky="w")
-        self.widgets["frequency_low"] = ttk.Entry(
+        self.widgets["standalone_frequency_low"] = ttk.Entry(
             row, width=8, textvariable=self.vars["frequency_low"]
         )
-        self.widgets["frequency_low"].grid(row=0, column=1, padx=(8, 20), sticky="w")
+        self.widgets["standalone_frequency_low"].grid(
+            row=0, column=1, padx=(8, 20), sticky="w"
+        )
 
         ttk.Label(row, text="High (Hz):").grid(row=0, column=2, sticky="w")
-        self.widgets["frequency_high"] = ttk.Entry(
+        self.widgets["standalone_frequency_high"] = ttk.Entry(
             row, width=8, textvariable=self.vars["frequency_high"]
         )
-        self.widgets["frequency_high"].grid(row=0, column=3, padx=(8, 0), sticky="w")
+        self.widgets["standalone_frequency_high"].grid(
+            row=0, column=3, padx=(8, 0), sticky="w"
+        )
 
         ToolTip(
-            self.widgets["frequency_low"],
+            self.widgets["standalone_frequency_low"],
             "Lower FSK frequency (Hz). Must be < High frequency.\nValid range: 2000–24000 Hz.",
             self.colors,
         )
         ToolTip(
-            self.widgets["frequency_high"],
+            self.widgets["standalone_frequency_high"],
             "Higher FSK frequency (Hz). Must be > Low frequency.\nValid range: 2000–24000 Hz.",
             self.colors,
         )
@@ -920,10 +932,12 @@ class FlashToolApp(tk.Tk):
         row.grid(row=0, column=0, sticky="w")
 
         ttk.Label(row, text="Level:").grid(row=0, column=0, sticky="w")
-        self.widgets["attenuation"] = ttk.Spinbox(
+        self.widgets["standalone_attenuation"] = ttk.Spinbox(
             row, from_=0, to=100, width=6, textvariable=self.vars["attenuation"]
         )
-        self.widgets["attenuation"].grid(row=0, column=1, padx=(8, 4), sticky="w")
+        self.widgets["standalone_attenuation"].grid(
+            row=0, column=1, padx=(8, 4), sticky="w"
+        )
         ttk.Label(row, text="%").grid(row=0, column=2, sticky="w", padx=(0, 12))
 
         self.widgets["standalone_attenuation_db_label"] = ttk.Label(
@@ -941,12 +955,14 @@ class FlashToolApp(tk.Tk):
         self.checkbox(
             row, 0, 0, "Enable ECC (Recommended)", self.vars["ecc_enabled"]
         ).grid(row=0, column=0, sticky="w")
-        self.widgets["ecc_level"] = ttk.Spinbox(
+        self.widgets["standalone_ecc_level"] = ttk.Spinbox(
             row, from_=0, to=100, width=6, textvariable=self.vars["ecc_level"]
         )
-        self.widgets["ecc_level"].grid(row=0, column=1, padx=(8, 0), sticky="w")
+        self.widgets["standalone_ecc_level"].grid(
+            row=0, column=1, padx=(8, 0), sticky="w"
+        )
         ToolTip(
-            self.widgets["ecc_level"],
+            self.widgets["standalone_ecc_level"],
             "Number of Reed-Solomon error-correction symbols (0-100).\nHigher = more robust, but longer transmissions.",
             self.colors,
         )
@@ -1020,18 +1036,19 @@ class FlashToolApp(tk.Tk):
             "write", lambda *_: self.toggle_ecc_level_field()
         )
 
-        self.widgets["frequency_low"].bind(
-            "<FocusOut>", lambda e: self.update_low_frequency()
-        )
-        self.widgets["frequency_low"].bind(
-            "<Return>", lambda e: self.update_low_frequency()
-        )
-        self.widgets["frequency_high"].bind(
-            "<FocusOut>", lambda e: self.update_high_frequency()
-        )
-        self.widgets["frequency_high"].bind(
-            "<Return>", lambda e: self.update_high_frequency()
-        )
+        for prefix in ("receiver", "standalone"):
+            self.widgets[f"{prefix}_frequency_low"].bind(
+                "<FocusOut>", lambda e: self.update_low_frequency()
+            )
+            self.widgets[f"{prefix}_frequency_low"].bind(
+                "<Return>", lambda e: self.update_low_frequency()
+            )
+            self.widgets[f"{prefix}_frequency_high"].bind(
+                "<FocusOut>", lambda e: self.update_high_frequency()
+            )
+            self.widgets[f"{prefix}_frequency_high"].bind(
+                "<Return>", lambda e: self.update_high_frequency()
+            )
 
         self.bind_all("<Button-1>", self.defocus_all, add="+")
         self.notebook.bind("<<NotebookTabChanged>>", self.on_tab_changed)
@@ -1047,15 +1064,18 @@ class FlashToolApp(tk.Tk):
 
     def toggle_interval_field(self):
         state = "disabled" if self.vars["default_interval"].get() else "normal"
-        self.widgets["interval"].config(state=state)
+        for key in ("base_interval", "standalone_interval"):
+            self.widgets[key].config(state=state)
 
     def toggle_delay_field(self):
         state = "normal" if self.vars["use_start_minute"].get() else "disabled"
-        self.widgets["start_minute"].config(state=state)
+        for key in ("base_start_minute", "standalone_start_minute"):
+            self.widgets[key].config(state=state)
 
     def toggle_ecc_level_field(self):
         state = "normal" if self.vars["ecc_enabled"].get() else "disabled"
-        self.widgets["ecc_level"].config(state=state)
+        for key in ("receiver_ecc_level", "standalone_ecc_level"):
+            self.widgets[key].config(state=state)
 
     def defocus_all(self, event):
         if isinstance(

--- a/Python/gui/scripts/user_config.py
+++ b/Python/gui/scripts/user_config.py
@@ -213,6 +213,9 @@ def change_user_config(root, set_initial_time, safe_log=None):
     }
 
     # Values to apply (use normalized ints)
+    # Set interval to 1 if using default interval, otherwise use the provided value
+    final_interval = 1 if use_default_interval else interval_minutes_i
+
     variables = {
         "USER_STRING": to_str(user_string),
         "DEVICE_ID": device_id_i,
@@ -235,7 +238,7 @@ def change_user_config(root, set_initial_time, safe_log=None):
         "ENABLE_DELAYED_START": bool(enable_delayed_start),
         "STARTING_MINUTE": delay_minutes_i,
         "USE_DEFAULT_INTERVAL_BETWEEN_REPEATS": bool(use_default_interval),
-        "INTERVAL_BETWEEN_REPEATS_MINUTES": interval_minutes_i,
+        "INTERVAL_BETWEEN_REPEATS_MINUTES": final_interval,
         "USE_CABLE_TRANSMISSION": bool(use_cable_transmission),
         "USE_SPEAKER_TRANSMISSION": bool(use_speaker_transmission),
         "SIGNAL_ATTENUATION": attenuation_i,

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -13,9 +13,9 @@ static const ism_reg_t cc1101_cfg_rx[] = {
     {0x07, 0x05}, // PKTCTRL1: address check enabled, no status bytes appended
     {0x08, 0x05}, // PKTCTRL0: variable length, CRC enabled, no data whitening
     {0x09, 0xEB}, // ADDR: device address = 0xEB
-    {0x0D, 0x10}, // FREQ2: carrier frequency high byte  \
-    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte    > 433 MHz
-    {0x0F, 0x62}, // FREQ0: carrier frequency low byte   /
+    {0x0D, 0x10}, // FREQ2: carrier frequency high byte
+    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte
+    {0x0F, 0x62}, // FREQ0: carrier frequency low byte
     {0x10, 0x85}, // MDMCFG4: channel BW=203kHz, DRATE_E=5 -> 1200 bps
     {0x11, 0x83}, // MDMCFG3: DRATE_M=131 -> 1200 bps
     {0x12,
@@ -39,9 +39,9 @@ static const ism_reg_t cc1101_cfg_tx[] = {
     {0x07, 0x05}, // PKTCTRL1: address check enabled, no status bytes appended
     {0x08, 0x05}, // PKTCTRL0: variable length, CRC enabled, no data whitening
     {0x09, 0xEB}, // ADDR: device address = 0xEB
-    {0x0D, 0x10}, // FREQ2: carrier frequency high byte  \
-    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte    > 433 MHz
-    {0x0F, 0x62}, // FREQ0: carrier frequency low byte   /
+    {0x0D, 0x10}, // FREQ2: carrier frequency high byte
+    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte
+    {0x0F, 0x62}, // FREQ0: carrier frequency low byte
     {0x10, 0x85}, // MDMCFG4: channel BW=203kHz, DRATE_E=5 -> 1200 bps
     {0x11, 0x83}, // MDMCFG3: DRATE_M=131 -> 1200 bps
     {0x12,

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -5,29 +5,25 @@ typedef struct {
 } ism_reg_t;
 
 static const ism_reg_t cc1101_cfg_rx[] = {
-    {0x02, 0x07}, // IOCFG0: GDO0 asserts when packet received with CRC OK,
-                  //         deasserts on first FIFO byte read
-    {0x04, 0xD3}, // SYNC1: sync word high byte = 0xD3
-    {0x05, 0x91}, // SYNC0: sync word low byte  = 0x91
-    {0x06, 0x3D}, // PKTLEN: max packet length = 61 bytes
-    {0x07, 0x05}, // PKTCTRL1: address check enabled, no status bytes appended
-    {0x08, 0x05}, // PKTCTRL0: variable length, CRC enabled, no data whitening
-    {0x09, 0xEB}, // ADDR: device address = 0xEB
-    {0x0D, 0x10}, // FREQ2: carrier frequency high byte
-    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte
-    {0x0F, 0x62}, // FREQ0: carrier frequency low byte
-    {0x10, 0x85}, // MDMCFG4: channel BW=203kHz, DRATE_E=5 -> 1200 bps
-    {0x11, 0x83}, // MDMCFG3: DRATE_M=131 -> 1200 bps
-    {0x12,
-     0x02}, // MDMCFG2: 2-FSK, 16/16 sync word bits, no Manchester encoding
-    {0x13, 0xF2}, // MDMCFG1: 24-byte preamble, FEC disabled
-    {0x17,
-     0x07}, // MCSM2: RX_TIME=7, stay in RX until packet done after WOR wake
-    {0x18, 0x18}, // MCSM0: FS_AUTOCAL=01, calibrate on IDLE->RX transition
-    {0x1E, 0x43}, // WOREVT1: EVENT0 high byte \  0x43CC = 17356 counts
-    {0x1F, 0xCC}, // WOREVT0: EVENT0 low byte   > ~500 ms WOR wake interval
-    {0x20, 0x78}, // WORCTRL: RC_PD=0, EVENT1=7 (~1.8ms CS window), RC_CAL=1,
-                  // WOR_RES=0
+    {0x02, 0x06}, // IOCFG0: Sync word detected (works in WOR)
+    {0x04, 0xD3}, // SYNC1
+    {0x05, 0x91}, // SYNC0
+    {0x06, 0x3D}, // PKTLEN
+    {0x07, 0x05}, // PKTCTRL1
+    {0x08, 0x05}, // PKTCTRL0
+    {0x09, 0xEB}, // ADDR
+    {0x0D, 0x10}, // FREQ2
+    {0x0E, 0xA7}, // FREQ1
+    {0x0F, 0x62}, // FREQ0
+    {0x10, 0x85}, // MDMCFG4
+    {0x11, 0x83}, // MDMCFG3
+    {0x12, 0x02}, // MDMCFG2
+    {0x13, 0xF2}, // MDMCFG1: FEC enabled (bit 7 = 1)
+    {0x17, 0x37}, // MCSM2: RX_TIME=7, EXITMASK enabled
+    {0x18, 0x08}, // MCSM0: FS_AUTOCAL=00 (no autocalibration) ← CHANGE
+    {0x1E, 0x10}, // WOREVT1: EVENT0 high byte (0x1080 = 264ms)
+    {0x1F, 0x80}, // WOREVT0: EVENT0 low byte
+    {0x20, 0x78}, // WORCTRL: RC_PD=0 (RC osc ON for WOR timing)
 };
 
 static const ism_reg_t cc1101_cfg_tx[] = {

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -5,7 +5,8 @@ typedef struct {
 } ism_reg_t;
 
 static const ism_reg_t cc1101_cfg_rx[] = {
-    {0x02, 0x06}, // IOCFG0: Sync word detected (works in WOR)
+    {0x02, 0x07}, // IOCFG0: GDO0 asserts when packet received with CRC OK,
+                  // deasserts on first FIFO byte read
     {0x04, 0xD3}, // SYNC1
     {0x05, 0x91}, // SYNC0
     {0x06, 0x3D}, // PKTLEN

--- a/STM32/Core/Inc/wakeup.h
+++ b/STM32/Core/Inc/wakeup.h
@@ -1,0 +1,18 @@
+#ifndef WAKEUP_H
+#define WAKEUP_H
+
+#include "ds3231.h"
+#include "main.h"
+#include "user_config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#define UNINITIALIZED 0xFF
+
+void WakeUp_Init(rtc_time_t now);
+void WakeUp_SetCurrentMinute(uint8_t minute);
+void WakeUp_CalculateNextValidMinute(void);
+bool WakeUp_CheckCurrentMinute(rtc_time_t now);
+
+#endif // WAKEUP_H

--- a/STM32/Core/Src/ds3231.c
+++ b/STM32/Core/Src/ds3231.c
@@ -101,9 +101,9 @@ void DS3231_GetTime(rtc_time_t *time) {
   time->month = DS3231_BcdToDec(get_time[5] & 0x1F);
   time->year = 2000 + DS3231_BcdToDec(get_time[6]);
 
-  LOGF("Read time from DS3231: %02d:%02d:%02d, %02d/%02d/%04d, DOW: %u\r\n",
-       time->hours, time->minutes, time->seconds, time->date, time->month,
-       time->year, time->day);
+  // LOGF("Read time from DS3231: %02d:%02d:%02d, %02d/%02d/%04d, DOW: %u\r\n",
+  //      time->hours, time->minutes, time->seconds, time->date, time->month,
+  //      time->year, time->day);
 
   return;
 }

--- a/STM32/Core/Src/ds3231.c
+++ b/STM32/Core/Src/ds3231.c
@@ -101,6 +101,10 @@ void DS3231_GetTime(rtc_time_t *time) {
   time->month = DS3231_BcdToDec(get_time[5] & 0x1F);
   time->year = 2000 + DS3231_BcdToDec(get_time[6]);
 
+  LOGF("Read time from DS3231: %02d:%02d:%02d, %02d/%02d/%04d, DOW: %u\r\n",
+       time->hours, time->minutes, time->seconds, time->date, time->month,
+       time->year, time->day);
+
   return;
 }
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -18,6 +18,7 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include "stm32g4xx_hal_rcc.h"
 #include "usb_device.h"
 
 /* Private includes ----------------------------------------------------------*/
@@ -96,7 +97,7 @@
 #define OUTPUT_SEGMENT 500
 #define BUFFER_SIZE (OUTPUT_SEGMENT * 5)
 
-#define SYNC_DELAY_MS 300
+#define SYNC_DELAY_MS 100 
 
 /* USER CODE END PD */
 
@@ -332,7 +333,11 @@ int main(void) {
   // interval
   //-----------------------------------------------------------------------------//
 
-  WakeUp_Init(now);
+  if (OPERATION_MODE != 0) {
+    WakeUp_Init(now);
+  } else {
+    LOGF("RX mode - skipping wakeup timer configuration\r\n");
+  }
 
   //-----------------------------------------------------------------------------//
   // Check battery voltage and go back to sleep if low
@@ -439,13 +444,34 @@ int main(void) {
   LOGF("Entering main loop...\r\n");
   LOGF("\r\n");
 
+  DS3231_PowerOn();
   DS3231_GetTime(&now);
+  DS3231_ReadTemperature(&temp_int);
+  DS3231_PowerOff();
+
+  uint32_t while_tick = 0;
+  uint32_t battery_tick = 0;
+  uint32_t rtc1_tick = 0;
+  uint32_t rtc2_tick = 0;
+  uint32_t active_tick = 0;
+  uint32_t rx_tick = 0;
+  uint32_t process_tick = 0;
+  uint32_t string_tick = 0;
+  uint32_t rs_tick = 0;
+  uint32_t bitstream_tick = 0;
+  uint32_t connection_tick = 0;
+  uint32_t arm_tick = 0;
+  uint32_t trigger_tick = 0;
+  uint32_t complete_tick = 0;
+  uint32_t done_tick = 0;
+  int32_t wait_ms = 0;
 
   while (1) {
     // 1) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7) or RTC
     // wakeup timer
     LOGF("Entering STOP mode...\r\n");
     EnterStopMode();
+    wake_up_tick = HAL_GetTick();
 
     // Set new wake up alarm for next cycle immediately after waking up
     // 55 seconds ensure we wake up in every minute to check if it's the valid
@@ -453,47 +479,35 @@ int main(void) {
     // timing variations
     if (OPERATION_MODE != 0) {
       uint32_t sleep_seconds = 55;
-      LOGF("Sleeping for %lu s\r\n", (unsigned long)sleep_seconds);
+      // LOGF("Sleeping for %lu s\r\n", (unsigned long)sleep_seconds);
       RTC_SetWakeupTimer(sleep_seconds);
     }
 
     // 2) Check battery voltage and go back to sleep if low
 
     Battery_IsLow(&hadc1);
+    battery_tick = HAL_GetTick() - wake_up_tick;
 
     // Update current minute from RTC
     DS3231_PowerOn();
     DS3231_GetTime(&now);
+    DS3231_ReadTemperature(&temp_int);
+
+    rtc1_tick = HAL_GetTick() - wake_up_tick;
 
     // Check if we are in the active window based on the current minute and
     // configured intervals, and if not, go back to sleep
     // Only for TX and Standalone modes
     if (OPERATION_MODE != 0) {
       if (!WakeUp_CheckCurrentMinute(now)) {
+        LOGF("Took %lu ms to check wakeup time\r\n",
+             (unsigned long)(HAL_GetTick() - wake_up_tick));
         LOGF("Not in active window, going back to sleep...\r\n");
         DS3231_PowerOff();
         continue;
       }
+      active_tick = HAL_GetTick() - wake_up_tick;
     }
-
-    // 3) Check if it is the starting minute for TX and Standalone modes
-    // if (ENABLE_DELAYED_START && first_boot) {
-    //   DS3231_GetTime(&now);
-    //   if (OPERATION_MODE != 0 && now.minutes != STARTING_MINUTE) {
-    //     LOGF("Not the starting minute yet (current minute: %02d), going back
-    //     "
-    //          "to sleep...\r\n",
-    //          now.minutes);
-    //     DS3231_PowerOff();
-
-    //     RTC_SetWakeupTimer(60); // check again in 1 minute
-
-    //     continue;
-    //   } else {
-    //     LOGF("It is the starting minute...");
-    //     first_boot = false;
-    //   }
-    // }
 
     if (OPERATION_MODE == 0) {
       LOGF("Woke up for RX reception\r\n");
@@ -501,16 +515,23 @@ int main(void) {
       // RX mode: read from radio and store in string
       int rx_len = Radio_Receive(transmission, sizeof(transmission));
       if (rx_len <= 4 || memchr(transmission, '/', rx_len) == NULL) {
+        LOGF(
+            "Failed to receive valid transmission, going back to sleep...\r\n");
+        DS3231_PowerOff();
         Radio_EnterWOR();
         continue;
       }
+      rx_tick = HAL_GetTick() - wake_up_tick;
+
       // Process received transmission
       process_transmission(transmission, &dBm_value);
+      process_tick = HAL_GetTick() - wake_up_tick;
 
       // 2) Get current time from RTC
       DS3231_GetTime(&now);
       DS3231_ReadTemperature(&temp_int);
       DS3231_PowerOff();
+      rtc2_tick = HAL_GetTick() - wake_up_tick;
 
       // Create output string based on received data (e.g.
       // "/TIM.../STR.../DID.../LOC.../TMP...")
@@ -518,6 +539,7 @@ int main(void) {
       create_string_from_received_data(transmission, dBm_value, output_str,
                                        sizeof(output_str));
 
+      string_tick = HAL_GetTick() - wake_up_tick;
       size_t payload_len = strlen((char *)output_str);
 
       if (USE_REED_SOLOMON_ERROR_CORRECTION) {
@@ -539,8 +561,11 @@ int main(void) {
         payload_len = codeword_len;
       }
 
+      rs_tick = HAL_GetTick() - wake_up_tick;
+
       // Make bitstream from output string
       make_bitstream_from_bytes(output_str, payload_len);
+      bitstream_tick = HAL_GetTick() - wake_up_tick;
 
       calculate_active_duration_ms(BITSTREAM_LENGTH);
       uint32_t total_ms = (uint32_t)(total_time * 1000.0f);
@@ -552,12 +577,13 @@ int main(void) {
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
         HAL_Delay(100);
       }
+      connection_tick = HAL_GetTick() - wake_up_tick;
 
       start_audio_arm();
+      arm_tick = HAL_GetTick() - wake_up_tick;
 
       uint32_t target_tick = wake_up_tick + SYNC_DELAY_MS;
-      int32_t wait_ms = (int32_t)(target_tick - HAL_GetTick());
-      LOGF("Sync wait: %ld ms\r\n", wait_ms);
+      wait_ms = (int32_t)(target_tick - HAL_GetTick());
       if (wait_ms > 1) {
         HAL_Delay((uint32_t)(wait_ms - 1));
       }
@@ -572,6 +598,7 @@ int main(void) {
       // moment
       while ((SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) == 0)
         ;
+      trigger_tick = HAL_GetTick() - wake_up_tick;
       start_audio_trigger();
       __HAL_UART_ENABLE(&huart2);
 
@@ -598,10 +625,14 @@ int main(void) {
 
     } else if (OPERATION_MODE == 1) {
       LOGF("Woke up for TX transmission\r\n");
+
       // Send transmission over radio
       LOGF("Starting transmission over radio...\r\n");
-      LED_BlinkStatusCode(STATUS_CODE_STARTING_TRANSMISSION);
+      LED_ON();
+      trigger_tick = HAL_GetTick() - wake_up_tick;
       Radio_Transmit();
+      LED_OFF();
+      done_tick = HAL_GetTick() - wake_up_tick;
     } else {
       LOGF("Woke up for Standalone mode\r\n");
 
@@ -610,6 +641,7 @@ int main(void) {
       DS3231_GetTime(&now);
       DS3231_ReadTemperature(&temp_int);
       DS3231_PowerOff();
+      rtc2_tick = HAL_GetTick() - wake_up_tick;
 
       // Create output string based on received data (e.g.
       // "/TIM.../STR.../DID.../LOC.../TMP...")
@@ -619,6 +651,7 @@ int main(void) {
                             INCLUDE_LOCATION ? LOCATION : NULL,
                             INCLUDE_TEMPERATURE ? temp_int : -1, now, false, -1,
                             output_str, sizeof(output_str));
+      string_tick = HAL_GetTick() - wake_up_tick;
 
       size_t payload_len = strlen((char *)output_str);
 
@@ -640,9 +673,11 @@ int main(void) {
         memcpy(output_str, codeword, codeword_len);
         payload_len = codeword_len;
       }
+      rs_tick = HAL_GetTick() - wake_up_tick;
 
       // Make bitstream from output string
       make_bitstream_from_bytes(output_str, payload_len);
+      bitstream_tick = HAL_GetTick() - wake_up_tick;
 
       calculate_active_duration_ms(BITSTREAM_LENGTH);
       uint32_t total_ms = (uint32_t)(total_time * 1000.0f);
@@ -655,8 +690,12 @@ int main(void) {
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
         HAL_Delay(100);
       }
+      connection_tick = HAL_GetTick() - wake_up_tick;
 
       start_audio_arm();
+      arm_tick = HAL_GetTick() - wake_up_tick;
+
+      trigger_tick = HAL_GetTick() - wake_up_tick;
       start_audio_trigger();
 
       // Wait for active window to complete (enters low-power sleep while
@@ -679,6 +718,81 @@ int main(void) {
       // Stop transmission and go back to sleep
       stop_audio_transmission();
     }
+    complete_tick = HAL_GetTick() - wake_up_tick;
+
+    if (OPERATION_MODE == 0) {
+      LOGF("Has to wait for synchronization: %ld ms\r\n", (long)wait_ms);
+      LOGF("Timing for RX cycle:\r\n");
+      LOGF("  Ticks for battery check: %lu ms\r\n",
+           (unsigned long)(battery_tick));
+      LOGF("  Ticks for RTC read 1: %lu ms\r\n",
+           (unsigned long)(rtc1_tick - battery_tick));
+      LOGF("  Ticks for RX reception: %lu ms\r\n",
+           (unsigned long)(rx_tick - rtc1_tick));
+      LOGF("  Ticks for processing received data: %lu ms\r\n",
+           (unsigned long)(process_tick - rx_tick));
+      LOGF("  Ticks for RTC read 2: %lu ms\r\n",
+           (unsigned long)(rtc2_tick - process_tick));
+      LOGF("  Ticks for creating output string: %lu ms\r\n",
+           (unsigned long)(string_tick - rtc2_tick));
+      LOGF("  Ticks for Reed-Solomon encoding: %lu ms\r\n",
+           (unsigned long)(rs_tick - string_tick));
+      LOGF("  Ticks for making bitstream: %lu ms\r\n",
+           (unsigned long)(bitstream_tick - rs_tick));
+      LOGF("  Ticks for connection setup: %lu ms\r\n",
+           (unsigned long)(connection_tick - bitstream_tick));
+      LOGF("  Ticks for arming audio: %lu ms\r\n",
+           (unsigned long)(arm_tick - connection_tick));
+      LOGF("  Ticks for triggering audio: %lu ms\r\n",
+           (unsigned long)(trigger_tick - arm_tick));
+      LOGF("  Total ticks from wakeup to audio trigger: %lu ms\r\n",
+           (unsigned long)(trigger_tick - wake_up_tick));
+    } else if (OPERATION_MODE == 1) {
+      LOGF("Timing for TX cycle:\r\n");
+      LOGF("  Ticks from wakeup to while loop start: %lu ms\r\n",
+           (unsigned long)(while_tick - wake_up_tick));
+      LOGF("  Ticks for battery check: %lu ms\r\n",
+           (unsigned long)(battery_tick - while_tick));
+      LOGF("  Ticks for RTC read: %lu ms\r\n",
+           (unsigned long)(rtc1_tick - battery_tick));
+      LOGF("  Ticks for check active minute: %lu ms\r\n",
+           (unsigned long)(active_tick - rtc1_tick));
+      LOGF("  Ticks for starting transmission: %lu ms\r\n",
+           (unsigned long)(trigger_tick - active_tick));
+      LOGF("  Ticks for transmission to complete: %lu ms\r\n",
+           (unsigned long)(done_tick - trigger_tick));
+      LOGF("  Total ticks from wakeup to transmission start: %lu ms\r\n",
+           (unsigned long)(done_tick - wake_up_tick));
+    } else {
+      LOGF("Timing for Standalone cycle:\r\n");
+      LOGF("  Ticks from wakeup to while loop start: %lu ms\r\n",
+           (unsigned long)(while_tick - wake_up_tick));
+      LOGF("  Ticks for battery check: %lu ms\r\n",
+           (unsigned long)(battery_tick - while_tick));
+      LOGF("  Ticks for RTC read: %lu ms\r\n",
+           (unsigned long)(rtc1_tick - battery_tick));
+      LOGF("  Ticks for check active minute: %lu ms\r\n",
+           (unsigned long)(active_tick - rtc1_tick));
+      LOGF("  Ticks for RTC read 2: %lu ms\r\n",
+           (unsigned long)(rtc2_tick - active_tick));
+      LOGF("  Ticks for creating output string: %lu ms\r\n",
+           (unsigned long)(string_tick - rtc2_tick));
+      LOGF("  Ticks for Reed-Solomon encoding: %lu ms\r\n",
+           (unsigned long)(rs_tick - string_tick));
+      LOGF("  Ticks for making bitstream: %lu ms\r\n",
+           (unsigned long)(bitstream_tick - rs_tick));
+      LOGF("  Ticks for connection setup: %lu ms\r\n",
+           (unsigned long)(connection_tick - bitstream_tick));
+      LOGF("  Ticks for arming audio: %lu ms\r\n",
+           (unsigned long)(arm_tick - connection_tick));
+      LOGF("  Ticks for triggering audio: %lu ms\r\n",
+           (unsigned long)(trigger_tick - arm_tick));
+      LOGF("  Total ticks from wakeup to audio trigger: %lu ms\r\n",
+           (unsigned long)(trigger_tick - wake_up_tick));
+    }
+    LOGF("Total ticks from wakeup to cycle complete: %lu ms\r\n",
+         (unsigned long)(complete_tick - wake_up_tick));
+    LOGF("-------------------------\r\n");
 
     /* USER CODE END WHILE */
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -172,6 +172,8 @@ extern volatile uint8_t cdc_rx_len;
 
 uint32_t wake_up_tick = 0;
 
+bool first_boot = true;
+
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -316,6 +318,11 @@ int main(void) {
   DS3231_ReadTemperature(&temp_int);
   DS3231_PowerOff();
 
+  LOGF("Current RTC time: %02d:%02d:%02d, %02d/%02d/%04d, DOW: %u\r\n",
+       now.hours, now.minutes, now.seconds, now.date, now.month,
+       now.year + 2000, now.day);
+  LOGF("Temperature: %d°C\r\n", temp_int);
+
   LOGF("-------------------------\r\n");
   LOGF("\r\n");
 
@@ -389,12 +396,26 @@ int main(void) {
   // Configure RX or TX mode
   //-----------------------------------------------------------------------------//
 
-  if (OPERATION_MODE == 0) {
-    Relay_SetBypassMode();
-  } else {
+  Relay_SetBypassMode();
+  if (OPERATION_MODE != 0) {
     LOGF("Setting first alarm for TX and Standalone mode\r\n");
-    // TODO: ajust timer to match user config for transmission intervals
-    RTC_SetWakeupTimer(60);
+    RTC_SetWakeupTimer(10); // 1 minute
+
+    if (ENABLE_DELAYED_START) {
+      LOGF("Delayed start enabled - device will wait until minute %u to start "
+           "TX and Standalone modes\r\n",
+           (unsigned int)STARTING_MINUTE);
+    } else {
+      LOGF("Delayed start disabled - device will start TX and Standalone modes "
+           "immediately\r\n");
+    }
+
+    if (USE_DEFAULT_INTERVAL_BETWEEN_REPEATS) {
+      LOGF("Using default interval of 60 minutes between repeats\r\n");
+    } else {
+      LOGF("Using user-configured interval of %u minutes between repeats\r\n",
+           (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
+    }
   }
 
   //-----------------------------------------------------------------------------//
@@ -418,6 +439,24 @@ int main(void) {
     // 2) Check battery voltage and go back to sleep if low
     Battery_IsLow(&hadc1);
     DS3231_PowerOn();
+
+    // 3) Check if it is the starting minute for TX and Standalone modes
+    if (ENABLE_DELAYED_START && first_boot) {
+      DS3231_GetTime(&now);
+      if (OPERATION_MODE != 0 && now.minutes != STARTING_MINUTE) {
+        LOGF("Not the starting minute yet (current minute: %02d), going back "
+             "to sleep...\r\n",
+             now.minutes);
+        DS3231_PowerOff();
+
+        RTC_SetWakeupTimer(60); // check again in 1 minute
+
+        continue;
+      } else {
+        LOGF("It is the starting minute...");
+        first_boot = false;
+      }
+    }
 
     if (OPERATION_MODE == 0) {
       LOGF("Woke up for RX reception\r\n");
@@ -640,12 +679,42 @@ int main(void) {
       stop_audio_transmission();
 
       // Set next wakeup timer for x minutes based on user config
-      uint32_t sleep_seconds;
+      uint32_t target_interval_s;
+
       if (USE_DEFAULT_INTERVAL_BETWEEN_REPEATS) {
-        sleep_seconds = 60;
+        target_interval_s = 60;
       } else {
-        sleep_seconds = INTERVAL_BETWEEN_REPEATS_MINUTES * 60;
+        target_interval_s = INTERVAL_BETWEEN_REPEATS_MINUTES * 60;
       }
+
+      uint32_t elapsed_ms = HAL_GetTick() - wake_up_tick;
+      uint32_t elapsed_s = elapsed_ms / 1000;
+
+      uint32_t sleep_seconds;
+      if (elapsed_s >= target_interval_s) {
+        sleep_seconds = 1;
+      } else {
+        uint32_t remainder_ms = elapsed_ms % 1000;
+
+        if (remainder_ms != 0) {
+          HAL_Delay(1000 - remainder_ms);
+        }
+
+        static uint32_t cycle_count = 0;
+        cycle_count++;
+
+        if ((cycle_count % 4) == 0) {
+          sleep_seconds = target_interval_s - elapsed_s - 2;
+        } else {
+          sleep_seconds = target_interval_s - elapsed_s - 3;
+        }
+      }
+
+      LOGF("Elapsed awake time: %lu ms\r\n", (unsigned long)elapsed_ms);
+      LOGF("Sleeping for %lu s\r\n", (unsigned long)sleep_seconds);
+
+      LOGF("Going back to sleep...\r\n");
+
       RTC_SetWakeupTimer(sleep_seconds);
     }
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -97,7 +97,7 @@
 #define OUTPUT_SEGMENT 500
 #define BUFFER_SIZE (OUTPUT_SEGMENT * 5)
 
-#define SYNC_DELAY_MS 100 
+#define SYNC_DELAY_MS 200
 
 /* USER CODE END PD */
 
@@ -628,9 +628,15 @@ int main(void) {
 
       // Send transmission over radio
       LOGF("Starting transmission over radio...\r\n");
+      // Toggle on Relay to make click sound at start of transmission for easier
+      // analysis
+      Relay_SetMixingMode();
+
       LED_ON();
       trigger_tick = HAL_GetTick() - wake_up_tick;
       Radio_Transmit();
+
+      Relay_SetBypassMode();
       LED_OFF();
       done_tick = HAL_GetTick() - wake_up_tick;
     } else {

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -38,6 +38,7 @@
 #include "reed_solomon.h"
 #include "relay.h"
 #include "user_config.h"
+#include "wakeup.h"
 
 // Standard library includes
 #include <cmsis_gcc.h>
@@ -327,6 +328,13 @@ int main(void) {
   LOGF("\r\n");
 
   //-----------------------------------------------------------------------------//
+  // Set first valid minute for wakeup based on current time and user-configured
+  // interval
+  //-----------------------------------------------------------------------------//
+
+  WakeUp_Init(now);
+
+  //-----------------------------------------------------------------------------//
   // Check battery voltage and go back to sleep if low
   //-----------------------------------------------------------------------------//
 
@@ -393,7 +401,13 @@ int main(void) {
   }
 
   //-----------------------------------------------------------------------------//
-  // Configure RX or TX mode
+  // Indicate boot complete with LED blinks
+  //-----------------------------------------------------------------------------//
+
+  LED_BlinkStatusCode(STATUS_CODE_OK); // code 0 = "0000" = 4 short blinks
+
+  //-----------------------------------------------------------------------------//
+  // Configure first wakeup timer for TX and Standalone modes
   //-----------------------------------------------------------------------------//
 
   Relay_SetBypassMode();
@@ -411,18 +425,12 @@ int main(void) {
     }
 
     if (USE_DEFAULT_INTERVAL_BETWEEN_REPEATS) {
-      LOGF("Using default interval of 60 minutes between repeats\r\n");
+      LOGF("Using default interval of 1 minute between repeats\r\n");
     } else {
       LOGF("Using user-configured interval of %u minutes between repeats\r\n",
            (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
     }
   }
-
-  //-----------------------------------------------------------------------------//
-  // Indicate boot complete with LED blinks
-  //-----------------------------------------------------------------------------//
-
-  LED_BlinkStatusCode(STATUS_CODE_OK); // code 0 = "0000" = 4 short blinks
 
   //-----------------------------------------------------------------------------//
   // Main loop
@@ -431,32 +439,61 @@ int main(void) {
   LOGF("Entering main loop...\r\n");
   LOGF("\r\n");
 
+  DS3231_GetTime(&now);
+
   while (1) {
-    // 1) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7)
+    // 1) Enter STOP mode and wait for wakeup from EXTI (GPIOB Pin 7) or RTC
+    // wakeup timer
     LOGF("Entering STOP mode...\r\n");
     EnterStopMode();
 
+    // Set new wake up alarm for next cycle immediately after waking up
+    // 55 seconds ensure we wake up in every minute to check if it's the valid
+    // minute for operation, even if we miss the exact wakeup timer match due to
+    // timing variations
+    if (OPERATION_MODE != 0) {
+      uint32_t sleep_seconds = 55;
+      LOGF("Sleeping for %lu s\r\n", (unsigned long)sleep_seconds);
+      RTC_SetWakeupTimer(sleep_seconds);
+    }
+
     // 2) Check battery voltage and go back to sleep if low
+
     Battery_IsLow(&hadc1);
+
+    // Update current minute from RTC
     DS3231_PowerOn();
+    DS3231_GetTime(&now);
 
-    // 3) Check if it is the starting minute for TX and Standalone modes
-    if (ENABLE_DELAYED_START && first_boot) {
-      DS3231_GetTime(&now);
-      if (OPERATION_MODE != 0 && now.minutes != STARTING_MINUTE) {
-        LOGF("Not the starting minute yet (current minute: %02d), going back "
-             "to sleep...\r\n",
-             now.minutes);
+    // Check if we are in the active window based on the current minute and
+    // configured intervals, and if not, go back to sleep
+    // Only for TX and Standalone modes
+    if (OPERATION_MODE != 0) {
+      if (!WakeUp_CheckCurrentMinute(now)) {
+        LOGF("Not in active window, going back to sleep...\r\n");
         DS3231_PowerOff();
-
-        RTC_SetWakeupTimer(60); // check again in 1 minute
-
         continue;
-      } else {
-        LOGF("It is the starting minute...");
-        first_boot = false;
       }
     }
+
+    // 3) Check if it is the starting minute for TX and Standalone modes
+    // if (ENABLE_DELAYED_START && first_boot) {
+    //   DS3231_GetTime(&now);
+    //   if (OPERATION_MODE != 0 && now.minutes != STARTING_MINUTE) {
+    //     LOGF("Not the starting minute yet (current minute: %02d), going back
+    //     "
+    //          "to sleep...\r\n",
+    //          now.minutes);
+    //     DS3231_PowerOff();
+
+    //     RTC_SetWakeupTimer(60); // check again in 1 minute
+
+    //     continue;
+    //   } else {
+    //     LOGF("It is the starting minute...");
+    //     first_boot = false;
+    //   }
+    // }
 
     if (OPERATION_MODE == 0) {
       LOGF("Woke up for RX reception\r\n");
@@ -492,8 +529,8 @@ int main(void) {
         RS_EncodeMsg((const uint8_t *)output_str, (int)payload_len, codeword,
                      RS_ERROR_CORRECTION_SYMBOLS);
 
-        // Set output_str to the codeword for transmission (truncated to fit if
-        // necessary)
+        // Set output_str to the codeword for transmission (truncated to fit
+        // if necessary)
         size_t codeword_len = payload_len + RS_ERROR_CORRECTION_SYMBOLS;
         if (codeword_len > sizeof(output_str)) {
           codeword_len = sizeof(output_str);
@@ -565,44 +602,6 @@ int main(void) {
       LOGF("Starting transmission over radio...\r\n");
       LED_BlinkStatusCode(STATUS_CODE_STARTING_TRANSMISSION);
       Radio_Transmit();
-
-      uint32_t target_interval_s;
-
-      if (USE_DEFAULT_INTERVAL_BETWEEN_REPEATS) {
-        target_interval_s = 60;
-      } else {
-        target_interval_s = INTERVAL_BETWEEN_REPEATS_MINUTES * 60;
-      }
-
-      uint32_t elapsed_ms = HAL_GetTick() - wake_up_tick;
-      uint32_t elapsed_s = elapsed_ms / 1000;
-
-      uint32_t sleep_seconds;
-      if (elapsed_s >= target_interval_s) {
-        sleep_seconds = 1;
-      } else {
-        uint32_t remainder_ms = elapsed_ms % 1000;
-
-        if (remainder_ms != 0) {
-          HAL_Delay(1000 - remainder_ms);
-        }
-
-        static uint32_t cycle_count = 0;
-        cycle_count++;
-
-        if ((cycle_count % 4) == 0) {
-          sleep_seconds = target_interval_s - elapsed_s - 2;
-        } else {
-          sleep_seconds = target_interval_s - elapsed_s - 3;
-        }
-      }
-
-      LOGF("Elapsed awake time: %lu ms\r\n", (unsigned long)elapsed_ms);
-      LOGF("Sleeping for %lu s\r\n", (unsigned long)sleep_seconds);
-
-      LOGF("Going back to sleep...\r\n");
-
-      RTC_SetWakeupTimer(sleep_seconds);
     } else {
       LOGF("Woke up for Standalone mode\r\n");
 
@@ -650,6 +649,7 @@ int main(void) {
 
       if (USE_CABLE_TRANSMISSION) {
         Opamps_Enable(&hdac1);
+        HAL_Delay(20);
         Relay_SetMixingMode();
       } else {
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
@@ -664,8 +664,9 @@ int main(void) {
       StartActiveWindowMs((uint32_t)(total_ms));
 
       uint32_t last_toggle = HAL_GetTick();
+      uint32_t now = 0;
       while (!active_done) {
-        uint32_t now = HAL_GetTick();
+        now = HAL_GetTick();
         if ((now - last_toggle) >= 100) { // blink every 100 ms
           last_toggle = now;
           LED_Toggle();
@@ -677,45 +678,6 @@ int main(void) {
 
       // Stop transmission and go back to sleep
       stop_audio_transmission();
-
-      // Set next wakeup timer for x minutes based on user config
-      uint32_t target_interval_s;
-
-      if (USE_DEFAULT_INTERVAL_BETWEEN_REPEATS) {
-        target_interval_s = 60;
-      } else {
-        target_interval_s = INTERVAL_BETWEEN_REPEATS_MINUTES * 60;
-      }
-
-      uint32_t elapsed_ms = HAL_GetTick() - wake_up_tick;
-      uint32_t elapsed_s = elapsed_ms / 1000;
-
-      uint32_t sleep_seconds;
-      if (elapsed_s >= target_interval_s) {
-        sleep_seconds = 1;
-      } else {
-        uint32_t remainder_ms = elapsed_ms % 1000;
-
-        if (remainder_ms != 0) {
-          HAL_Delay(1000 - remainder_ms);
-        }
-
-        static uint32_t cycle_count = 0;
-        cycle_count++;
-
-        if ((cycle_count % 4) == 0) {
-          sleep_seconds = target_interval_s - elapsed_s - 2;
-        } else {
-          sleep_seconds = target_interval_s - elapsed_s - 3;
-        }
-      }
-
-      LOGF("Elapsed awake time: %lu ms\r\n", (unsigned long)elapsed_ms);
-      LOGF("Sleeping for %lu s\r\n", (unsigned long)sleep_seconds);
-
-      LOGF("Going back to sleep...\r\n");
-
-      RTC_SetWakeupTimer(sleep_seconds);
     }
 
     /* USER CODE END WHILE */
@@ -1327,10 +1289,6 @@ void update_input_string(void) {
 
 // Function to generate sine wave lookup table for low frequency
 void get_sineval_low(void) {
-  if (!sine_val_low || freq_pair.lower_freq_samples == 0) {
-    return; // eller Error_Handler()
-  }
-
   const float dac_max = 4095.0f;
   const float dac_mid = dac_max / 2.0f;
   const float amplitude = (1.5f / 1.65f) * (SIGNAL_ATTENUATION / 100.0f);
@@ -1345,10 +1303,6 @@ void get_sineval_low(void) {
 
 // Function to generate sine wave lookup table for the high frequency
 void get_sineval_high(void) {
-  if (!sine_val_high || freq_pair.higher_freq_samples == 0) {
-    return; // eller Error_Handler()
-  }
-
   const float dac_max = 4095.0f;
   const float dac_mid = dac_max / 2.0f;
   const float amplitude = (1.5f / 1.65f) * (SIGNAL_ATTENUATION / 100.0f);
@@ -1362,10 +1316,6 @@ void get_sineval_high(void) {
 }
 
 void get_dc_mid(void) {
-  if (!dc_mid || freq_pair.lower_freq_samples == 0) {
-    return; // eller Error_Handler()
-  }
-
   uint32_t mid_value = (uint32_t)(4095.0 / 2.0);
   for (uint16_t i = 0; i < freq_pair.lower_freq_samples; i++) {
     dc_mid[i] = mid_value;
@@ -1682,6 +1632,7 @@ void create_payload_string(const char *user_str, int device_id,
       remaining -= (size_t)n;
     }
   }
+
   // Add termination slash
   if (strlen(temp_buf) > 0) {
     n = snprintf(&temp_buf[offset], remaining, "/");
@@ -1708,71 +1659,51 @@ void create_string_from_received_data(const uint8_t *transmission,
     return;
 
   // Defaults (fallback if missing in RX packet)
-  int mid = 0; // default MID if missing
+  int mid = 0;
   char user_string[64] = USER_STRING;
   int device_id = DEVICE_ID;
   char location[64] = LOCATION;
   int8_t temperature = temp_int;
   rtc_time_t time_val = now;
 
-  // Make local copy for strtok (DO NOT modify input buffer)
+  // Make local copy for strtok
   char buf[256] = {0};
   strncpy(buf, (const char *)transmission, sizeof(buf) - 1);
 
-  // Parse tokens
+  // Parse tokens separated by /
   for (char *tok = strtok(buf, "/"); tok != NULL; tok = strtok(NULL, "/")) {
-    if (strncmp(tok, "MID", 3) == 0) {
-      // MID is two digits
-      char mid_buf[3] = {0};
-      mid_buf[0] = tok[3];
-      mid_buf[1] = tok[4];
-      mid = atoi(mid_buf);
-    }
+    // Extract type (first 3 chars) and data (remaining chars)
+    if (strlen(tok) < 3)
+      continue;
 
-    if (strncmp(tok, "TIM", 3) == 0) {
-      const char *p = tok + 3;
+    char type[4] = {0};
+    strncpy(type, tok, 3);
+    const char *data = tok + 3;
 
-      if (strlen(p) >= 16) {
-        char tmp[5] = {0};
-
-        tmp[0] = p[0];
-        tmp[1] = p[1];
-        time_val.hours = atoi(tmp);
-
-        tmp[0] = p[2];
-        tmp[1] = p[3];
-        time_val.minutes = atoi(tmp);
-
-        tmp[0] = p[4];
-        tmp[1] = p[5];
-        time_val.seconds = atoi(tmp);
-
-        tmp[0] = p[6];
-        tmp[1] = p[7];
-        time_val.day = atoi(tmp);
-
-        tmp[0] = p[8];
-        tmp[1] = p[9];
-        time_val.date = atoi(tmp);
-
-        tmp[0] = p[10];
-        tmp[1] = p[11];
-        time_val.month = atoi(tmp);
-
-        tmp[0] = p[12];
-        tmp[1] = p[13];
-        tmp[2] = p[14];
-        tmp[3] = p[15];
-        time_val.year = atoi(tmp);
+    // Route by type
+    if (strcmp(type, "MID") == 0) {
+      if (strlen(data) >= 2) {
+        char mid_buf[3] = {0};
+        strncpy(mid_buf, data, 2);
+        mid = atoi(mid_buf);
       }
-    } else if (strncmp(tok, "STR", 3) == 0) {
-      strncpy(user_string, tok + 3, sizeof(user_string) - 1);
-    } else if (strncmp(tok, "DID", 3) == 0) {
-      device_id = atoi(tok + 3);
-    } else if (strncmp(tok, "LOC", 3) == 0) {
-      strncpy(location, tok + 3, sizeof(location) - 1);
-    } else if (strncmp(tok, "TMP", 3) == 0) {
-      temperature = (int8_t)atoi(tok + 3);
+    } else if (strcmp(type, "TIM") == 0) {
+      if (strlen(data) >= 16) {
+        int hours = 0, minutes = 0, seconds = 0;
+        int day = 0, date = 0, month = 0, year = 0;
+        if (sscanf(data, "%2d%2d%2d%2d%2d%2d%4d", &hours, &minutes, &seconds,
+                   &day, &date, &month, &year) == 7) {
+          time_val.hours = (uint8_t)hours;
+          time_val.minutes = (uint8_t)minutes;
+          time_val.seconds = (uint8_t)seconds;
+          time_val.day = (uint8_t)day;
+          time_val.date = (uint8_t)date;
+          time_val.month = (uint8_t)month;
+          time_val.year = (uint16_t)year;
+        }
+      }
+    } else if (strcmp(type, "STR") == 0) {
+      strncpy(user_string, data, sizeof(user_string) - 1);
     }
   }
 
@@ -1827,12 +1758,10 @@ void TryReceiveTimeSync(void) {
   while (HAL_GetTick() - start < 10000) {
     if (cdc_rx_len > 0) {
       uint8_t len = cdc_rx_len;
-      cdc_rx_len = 0; // clear immediately
-
+      cdc_rx_len = 0;
       memcpy(buf, (uint8_t *)cdc_rx_buf, len);
       buf[len] = '\0';
 
-      // strip \r\n
       for (int i = 0; i < len; i++) {
         if (buf[i] == '\r' || buf[i] == '\n') {
           buf[i] = '\0';
@@ -1844,17 +1773,32 @@ void TryReceiveTimeSync(void) {
         int h, m, s, dow, day, mon, year;
         if (sscanf(buf + 1, "%d:%d:%d %d %d/%d/%d", &h, &m, &s, &dow, &day,
                    &mon, &year) == 7) {
+
+          uint32_t t0 = HAL_GetTick();
+
           DS3231_PowerOn();
+          uint32_t t1 = HAL_GetTick();
+          LOGF("[TIMING] PowerOn: %lu ms\r\n", t1 - t0);
+
           HAL_Delay(5);
+          uint32_t t2 = HAL_GetTick();
+
           DS3231_Init();
+          uint32_t t3 = HAL_GetTick();
+          LOGF("[TIMING] Init: %lu ms\r\n", t3 - t2);
+
           DS3231_SetTime(s, m, h, dow, day, mon, year);
+          uint32_t t4 = HAL_GetTick();
+          LOGF("[TIMING] SetTime: %lu ms\r\n", t4 - t3);
+          LOGF("[TIMING] Total: %lu ms\r\n", t4 - t0);
+
           DS3231_PowerOff();
+
           LOGF("Time synced: %02d:%02d:%02d %02d/%02d/%04d\r\n", h, m, s, day,
                mon, year);
           LED_Toggle();
           HAL_Delay(50);
           LED_Toggle();
-
           return;
         }
       }

--- a/STM32/Core/Src/opamps.c
+++ b/STM32/Core/Src/opamps.c
@@ -15,7 +15,6 @@ void Opamps_Enable(DAC_HandleTypeDef *hdac1) {
 void Opamps_Disable(DAC_HandleTypeDef *hdac1) {
   DAC_SetZero(hdac1);
   HAL_GPIO_WritePin(OPAMP_POWER_GPIO_Port, OPAMP_POWER_Pin, GPIO_PIN_RESET);
-
 }
 
 void DAC_SetZero(DAC_HandleTypeDef *hdac1) {
@@ -26,7 +25,7 @@ void DAC_SetZero(DAC_HandleTypeDef *hdac1) {
   HAL_DAC_Start(hdac1, DAC_CHANNEL_1);
 
   HAL_DAC_SetValue(hdac1, DAC_CHANNEL_1, DAC_ALIGN_12B_R, 0);
-  LOGF("DAC output set to zero\r\n");
+  // LOGF("DAC output set to zero\r\n");
 }
 
 void DAC_SetMidlevel(DAC_HandleTypeDef *hdac1, uint16_t mid_value) {
@@ -37,5 +36,5 @@ void DAC_SetMidlevel(DAC_HandleTypeDef *hdac1, uint16_t mid_value) {
 
   // Set mid-scale (12-bit right aligned)
   HAL_DAC_SetValue(hdac1, DAC_CHANNEL_1, DAC_ALIGN_12B_R, mid_value);
-  LOGF("DAC output set to mid-level\r\n");
+  // LOGF("DAC output set to mid-level\r\n");
 }

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -31,6 +31,7 @@ int8_t Radio_InitRXMode(void) {
   }
 
   CC1101_Strobe(0x33, &status); // SCAL
+  HAL_Delay(2);
   CC1101_Strobe(0x38, &status); // SWOR
 
   HAL_Delay(10);
@@ -168,20 +169,18 @@ void Radio_Transmit(void) {
 
     CC1101_Strobe(0x35, &status); // STX
 
-    // Wait for IDLE with 2000 ms timeout
-    uint32_t tx_start = HAL_GetTick();
-    while (1) {
-      uint8_t marcstate = 0;
-      CC1101_ReadReg(0xF5, &marcstate, &status);
-      marcstate &= 0x1F;
-      if (marcstate == 0x01)
-        break; // IDLE — TX done
-      if (HAL_GetTick() - tx_start > 2000) {
-        LOGF("TX timeout on repeat %d, forcing IDLE.\r\n", tx_repeat + 1);
-        CC1101_Strobe(0x36, &status); // SIDLE
-        break;
-      }
-    }
+    // DEBUG: Check TX state
+    uint8_t marcstate = 0;
+    HAL_Delay(50);
+    CC1101_ReadReg(0xF5, &marcstate, &status);
+    marcstate &= 0x1F;
+    LOGF("DEBUG: After STX strobe, MARCSTATE=0x%02X ", marcstate);
+    if (marcstate == 0x13)
+      LOGF("(TX)\r\n");
+    else if (marcstate == 0x01)
+      LOGF("(IDLE - TX failed)\r\n");
+    else
+      LOGF("(UNKNOWN)\r\n");
 
     free((void *)payload_str);
   }
@@ -219,7 +218,7 @@ void Radio_EnterWOR(void) {
   uint8_t status = 0;
 
   CC1101_Strobe(0x36, &status); // SIDLE
-  HAL_Delay(1);
+  HAL_Delay(5);
   CC1101_Strobe(0x3A, &status); // SFRX
   HAL_Delay(10);
   CC1101_Strobe(0x38, &status); // SWOR

--- a/STM32/Core/Src/relay.c
+++ b/STM32/Core/Src/relay.c
@@ -20,8 +20,8 @@ void Relay_SetMixingMode(void) {
   HAL_Delay(RELAY_TOGGLE_DELAY_MS);
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_RESET);
 
-  LOGF("Set relay to mixing mode\r\n");
-  LOGF("--------------------------\r\n");
+  // LOGF("Set relay to mixing mode\r\n");
+  // LOGF("--------------------------\r\n");
 }
 
 void Relay_SetBypassMode(void) {
@@ -31,6 +31,6 @@ void Relay_SetBypassMode(void) {
   HAL_Delay(RELAY_TOGGLE_DELAY_MS);
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_OFF, GPIO_PIN_RESET);
 
-  LOGF("Set relay to bypass mode\r\n");
-  LOGF("--------------------------\r\n");
+  // LOGF("Set relay to bypass mode\r\n");
+  // LOGF("--------------------------\r\n");
 }

--- a/STM32/Core/Src/relay.c
+++ b/STM32/Core/Src/relay.c
@@ -6,7 +6,7 @@
 #define RELAY_GPIO_Port GPIOA
 #define RELAY_PIN_ON GPIO_PIN_6
 #define RELAY_PIN_OFF GPIO_PIN_5
-#define RELAY_TOGGLE_DELAY_MS 10
+#define RELAY_TOGGLE_DELAY_MS 100
 
 void Relay_ResetBoth(void) {
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_RESET);

--- a/STM32/Core/Src/relay.c
+++ b/STM32/Core/Src/relay.c
@@ -6,7 +6,7 @@
 #define RELAY_GPIO_Port GPIOA
 #define RELAY_PIN_ON GPIO_PIN_6
 #define RELAY_PIN_OFF GPIO_PIN_5
-#define RELAY_TOGGLE_DELAY_MS 100
+#define RELAY_TOGGLE_DELAY_MS 10
 
 void Relay_ResetBoth(void) {
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_RESET);
@@ -19,9 +19,6 @@ void Relay_SetMixingMode(void) {
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_SET);
   HAL_Delay(RELAY_TOGGLE_DELAY_MS);
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_RESET);
-
-  // LOGF("Set relay to mixing mode\r\n");
-  // LOGF("--------------------------\r\n");
 }
 
 void Relay_SetBypassMode(void) {
@@ -30,7 +27,4 @@ void Relay_SetBypassMode(void) {
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_OFF, GPIO_PIN_SET);
   HAL_Delay(RELAY_TOGGLE_DELAY_MS);
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_OFF, GPIO_PIN_RESET);
-
-  // LOGF("Set relay to bypass mode\r\n");
-  // LOGF("--------------------------\r\n");
 }

--- a/STM32/Core/Src/wakeup.c
+++ b/STM32/Core/Src/wakeup.c
@@ -25,25 +25,24 @@ void WakeUp_SetCurrentMinute(uint8_t minute) { current_minute = minute; }
 void WakeUp_CalculateNextValidMinute(void) {
   if (next_valid_minute == UNINITIALIZED) {
     if (ENABLE_DELAYED_START && current_minute != STARTING_MINUTE) {
-      LOGF("Setting next valid minute to starting minute %02d\r\n",
-           STARTING_MINUTE);
+      // LOGF("Setting next valid minute to starting minute %02d\r\n",
+      //      STARTING_MINUTE);
       next_valid_minute = STARTING_MINUTE;
       return;
 
     } else {
 
-      LOGF("Calculating next valid minute based on current minute %02d and "
-           "configured interval of %u minutes\r\n",
-           current_minute, (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
-      next_valid_minute =
-          (current_minute + INTERVAL_BETWEEN_REPEATS_MINUTES) % 60;
+      LOGF("No valid minute configured, setting next valid minute to current "
+           "minute "
+           "+ 1 (wraps around at 60)\r\n");
+      next_valid_minute = (current_minute + 1) % 60;
 
       return;
     }
   } else {
-    LOGF("Calculating next valid minute based on last valid minute %02d and "
-         "configured interval of %u minutes\r\n",
-         next_valid_minute, (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
+    // LOGF("Calculating next valid minute based on last valid minute %02d and "
+    //      "configured interval of %u minutes\r\n",
+    //      next_valid_minute, (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
     next_valid_minute =
         (next_valid_minute + INTERVAL_BETWEEN_REPEATS_MINUTES) % 60;
   }
@@ -51,26 +50,26 @@ void WakeUp_CalculateNextValidMinute(void) {
 
 bool WakeUp_CheckCurrentMinute(rtc_time_t now) {
   WakeUp_SetCurrentMinute(now.minutes);
-  LOGF("Current minute: %02d\r\n", current_minute);
+  // LOGF("Current minute: %02d\r\n", current_minute);
 
   bool is_valid_minute = (current_minute == next_valid_minute);
 
   if (is_valid_minute) {
-    LOGF("Valid minute hit!\r\n");
+    // LOGF("Valid minute hit!\r\n");
     if (INTERVAL_BETWEEN_REPEATS_MINUTES > 5) {
       active_until_minute = (current_minute + 4) % 60;
     }
     WakeUp_CalculateNextValidMinute();
-    LOGF("Next valid minute after this window: %02d\r\n", next_valid_minute);
+    // LOGF("Next valid minute after this window: %02d\r\n", next_valid_minute);
   }
 
   if (active_until_minute != UNINITIALIZED) {
     if (current_minute > active_until_minute) {
-      LOGF("Active window ended.\r\n");
+      // LOGF("Active window ended.\r\n");
       active_until_minute = UNINITIALIZED;
       return false;
     }
-    LOGF("Currently in active window.\r\n");
+    // LOGF("Currently in active window.\r\n");
     return true;
   }
 

--- a/STM32/Core/Src/wakeup.c
+++ b/STM32/Core/Src/wakeup.c
@@ -1,0 +1,80 @@
+#include "wakeup.h"
+#include "ds3231.h"
+#include "log.h"
+#include "main.h"
+#include "user_config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+uint8_t current_minute = 0;
+
+uint8_t next_valid_minute = UNINITIALIZED;
+uint8_t active_until_minute = UNINITIALIZED;
+
+void WakeUp_Init(rtc_time_t now) {
+  WakeUp_SetCurrentMinute(now.minutes);
+  LOGF("Initializing WakeUp module with current minute: %02d\r\n",
+       current_minute);
+  WakeUp_CalculateNextValidMinute();
+  LOGF("Initial next valid minute: %02d\r\n", next_valid_minute);
+}
+
+void WakeUp_SetCurrentMinute(uint8_t minute) { current_minute = minute; }
+
+void WakeUp_CalculateNextValidMinute(void) {
+  if (next_valid_minute == UNINITIALIZED) {
+    if (ENABLE_DELAYED_START && current_minute != STARTING_MINUTE) {
+      LOGF("Setting next valid minute to starting minute %02d\r\n",
+           STARTING_MINUTE);
+      next_valid_minute = STARTING_MINUTE;
+      return;
+
+    } else {
+
+      LOGF("Calculating next valid minute based on current minute %02d and "
+           "configured interval of %u minutes\r\n",
+           current_minute, (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
+      next_valid_minute =
+          (current_minute + INTERVAL_BETWEEN_REPEATS_MINUTES) % 60;
+
+      return;
+    }
+  } else {
+    LOGF("Calculating next valid minute based on last valid minute %02d and "
+         "configured interval of %u minutes\r\n",
+         next_valid_minute, (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
+    next_valid_minute =
+        (next_valid_minute + INTERVAL_BETWEEN_REPEATS_MINUTES) % 60;
+  }
+}
+
+bool WakeUp_CheckCurrentMinute(rtc_time_t now) {
+  WakeUp_SetCurrentMinute(now.minutes);
+  LOGF("Current minute: %02d\r\n", current_minute);
+
+  bool is_valid_minute = (current_minute == next_valid_minute);
+
+  if (is_valid_minute) {
+    LOGF("Valid minute hit!\r\n");
+    if (INTERVAL_BETWEEN_REPEATS_MINUTES > 5) {
+      active_until_minute = (current_minute + 4) % 60;
+    }
+    WakeUp_CalculateNextValidMinute();
+    LOGF("Next valid minute after this window: %02d\r\n", next_valid_minute);
+  }
+
+  if (active_until_minute != UNINITIALIZED) {
+    if (current_minute > active_until_minute) {
+      LOGF("Active window ended.\r\n");
+      active_until_minute = UNINITIALIZED;
+      return false;
+    }
+    LOGF("Currently in active window.\r\n");
+    return true;
+  }
+
+  return is_valid_minute; // Return true if valid minute hit
+}
+
+// 1 second off at 12:19:58 (really 12:19:59)

--- a/STM32/extra_sources.cmake
+++ b/STM32/extra_sources.cmake
@@ -12,6 +12,7 @@ file(GLOB USER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/radio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/reed_solomon.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/relay.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/wakeup.c
 )
 
 # Collect all user include directories


### PR DESCRIPTION
This pull request primarily refactors the naming of widget keys in the `Python/gui/gui.py` file to clearly distinguish between widgets belonging to different tabs (base, receiver, standalone) and updates related logic accordingly. Additionally, it introduces a new header file for wakeup logic in the STM32 firmware, tweaks radio configuration for the CC1101, and makes minor improvements and bug fixes in the Python GUI and STM32 code.

The most important changes are:

**Python GUI Refactoring and Improvements:**

* Refactored widget dictionary keys in `gui.py` to use tab-specific prefixes (e.g., `base_interval`, `receiver_device_id`, `standalone_frequency_high`) for clarity and to prevent key collisions between tabs. All widget references and related methods have been updated to use the new naming scheme. [[1]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL589-R589) [[2]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL656-R659) [[3]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL807-R818) [[4]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL888-R917)
* Updated event binding and dynamic state logic to work with the new widget key names, using loops to bind events and set widget states for each tab. [[1]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL1023-R1049) [[2]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL1050-R1078)
* Fixed logic in `user_config.py` to ensure that when the default interval is used, the interval value is set to 1; otherwise, the user-provided value is used. [[1]](diffhunk://#diff-5950c703c8d69b61358a25e0aa2d055ed88c48ce5151da7c600b81282669c157R216-R218) [[2]](diffhunk://#diff-5950c703c8d69b61358a25e0aa2d055ed88c48ce5151da7c600b81282669c157L238-R241)

**STM32 Firmware Enhancements:**

* Added a new `wakeup.h` header for wakeup-related functions and constants, improving modularity and code organization.
* Updated the CC1101 radio configuration in `cc1101_config.h` with revised comments, register values, and settings for RX/TX, including enabling FEC, adjusting calibration, and changing wake-on-radio intervals. [[1]](diffhunk://#diff-396008bce731cb9cfeca601e60d25c5a33d3f209b63bcfd058ba4e715f8999adL10-R27) [[2]](diffhunk://#diff-396008bce731cb9cfeca601e60d25c5a33d3f209b63bcfd058ba4e715f8999adL42-R41)
* Minor improvements in STM32 source files: added new includes for `wakeup.h` and `stm32g4xx_hal_rcc.h`, and reduced `SYNC_DELAY_MS` from 300ms to 200ms. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R21) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R42) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L98-R100)
* Added commented-out debug logging for time reads in `ds3231.c`.