### PR TITLE
Enhance power management and sleep functionality for radio control

### DIFF
--- a/PCB/Audio_watermark_generator.kicad_prl
+++ b/PCB/Audio_watermark_generator.kicad_prl
@@ -1,6 +1,6 @@
 {
   "board": {
-    "active_layer": 23,
+    "active_layer": 0,
     "active_layer_preset": "",
     "auto_track_width": false,
     "hidden_netclasses": [],
@@ -8,7 +8,7 @@
       "GND",
       "+3.3V"
     ],
-    "high_contrast_mode": 1,
+    "high_contrast_mode": 0,
     "net_color_mode": 1,
     "opacity": {
       "images": 0.5699999928474426,

--- a/Python/gui/scripts/build.py
+++ b/Python/gui/scripts/build.py
@@ -10,7 +10,7 @@ import tempfile
 import pathlib
 import serial
 import serial.tools.list_ports
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from scripts.paths import *
 from scripts.user_config import *
@@ -243,45 +243,112 @@ def send_time_sync(root, safe_log):
 
     messagebox.showinfo(
         "Toggle BOOT0",
-        "Flash complete!\n\nNow set BOOT0 LOW and power-cycle or replug the device.\n\nClick OK when done.",
+        "Flash complete!\n\nSet BOOT0 LOW and power-cycle. Click OK when done.",
     )
-
-    time.sleep(3)
 
     port = None
-    all_ports = serial.tools.list_ports.comports()
-    safe_log(
-        f"[DEBUG] Available ports: {[(p.device, p.description) for p in all_ports]}"
-    )
-
-    for p in all_ports:
-        desc = (p.description or "").lower()
-        hwid = (p.hwid or "").lower()
-        device = (p.device or "").lower()
-        if any(
-            x in desc or x in hwid or x in device
-            for x in ["stm32", "usbmodem", "0483:5740"]
-        ):
-            port = p.device
+    for attempt in range(60):
+        all_ports = serial.tools.list_ports.comports()
+        for p in all_ports:
+            if any(
+                x in (p.description or p.hwid or p.device or "").lower()
+                for x in ["stm32", "usbmodem", "0483:5740"]
+            ):
+                port = p.device
+                break
+        if port:
             break
+        time.sleep(0.1)
 
     if not port:
         safe_log("[WARN] STM32 CDC port not found, skipping time sync")
-        safe_log(
-            "[INFO] You can set time manually by sending T<HH>:<MM>:<SS> <DOW> <DD>/<MM>/<YYYY> over serial"
-        )
         return
 
-    now = datetime.now()
-    dow = (now.weekday() + 1) % 7  # Convert Python's 0=Mon..6=Sun to 0=Sun..6=Sat
-    time_str = f"T{now.hour:02d}:{now.minute:02d}:{now.second:02d} {dow} {now.day:02d}/{now.month:02d}/{now.year}\n"
-
     try:
-        with serial.Serial(port, 115200, timeout=2) as ser:
-            time.sleep(0.5)  # let CDC settle before writing
-            safe_log(f"[INFO] Sending: {time_str.strip()} on {port}")
+        with serial.Serial(port, 115200, timeout=10) as ser:
+            time.sleep(2)
+            safe_log(f"[INFO] Listening on {port}...")
+
+            ready = False
+            start = time.time()
+            while time.time() - start < 10:
+                try:
+                    line = ser.readline().decode("utf-8", errors="ignore").strip()
+                    if line:
+                        safe_log(f"[DEBUG] {line}")
+                    if "READY_FOR_TIME_SYNC" in line:
+                        ready = True
+                        break
+                except:
+                    pass
+
+            if not ready:
+                safe_log("[WARN] Never received READY_FOR_TIME_SYNC")
+                return
+
+            # Sample time and send
+            sent_time = datetime.now()
+            dow = (sent_time.weekday() + 1) % 7
+            time_str = f"T{sent_time.hour:02d}:{sent_time.minute:02d}:{sent_time.second:02d} {dow} {sent_time.day:02d}/{sent_time.month:02d}/{sent_time.year}\n"
+
+            safe_log(
+                f"[INFO] Sent time: {sent_time.hour:02d}:{sent_time.minute:02d}:{sent_time.second:02d}"
+            )
             ser.write(time_str.encode())
-            safe_log("[OK] Time sync sent")
+
+            # Wait for readback
+            safe_log("[INFO] Waiting for readback (5s delay)...")
+            readback = None
+            start = time.time()
+            while time.time() - start < 10:
+                try:
+                    line = ser.readline().decode("utf-8", errors="ignore").strip()
+                    if line:
+                        safe_log(f"[DEBUG] {line}")
+                    if "READBACK:" in line:
+                        readback = line.split("READBACK:")[1]
+                        break
+                except:
+                    pass
+
+            if readback:
+                # Parse readback HH:MM:SS DD/MM/YYYY
+                parts = readback.split()
+                time_part = parts[0]  # HH:MM:SS
+                date_part = parts[1]  # DD/MM/YYYY
+
+                rb_h, rb_m, rb_s = map(int, time_part.split(":"))
+                rb_d, rb_mo, rb_y = map(int, date_part.split("/"))
+
+                # Calculate expected time (sent + 5 seconds)
+                expected_time = sent_time + timedelta(seconds=5)
+
+                # Compare
+                safe_log(
+                    f"[INFO] Sent:     {sent_time.hour:02d}:{sent_time.minute:02d}:{sent_time.second:02d}"
+                )
+                safe_log(
+                    f"[INFO] Expected: {expected_time.hour:02d}:{expected_time.minute:02d}:{expected_time.second:02d} (sent + 5s)"
+                )
+                safe_log(f"[INFO] Readback: {rb_h:02d}:{rb_m:02d}:{rb_s:02d}")
+
+                # Check if within 1 second
+                diff_s = abs(
+                    (rb_h * 3600 + rb_m * 60 + rb_s)
+                    - (
+                        expected_time.hour * 3600
+                        + expected_time.minute * 60
+                        + expected_time.second
+                    )
+                )
+
+                if diff_s <= 1:
+                    safe_log(f"[✓] SYNC OK - within 1 second (diff: {diff_s}s)")
+                else:
+                    safe_log(f"[✗] SYNC FAIL - off by {diff_s} seconds")
+            else:
+                safe_log("[WARN] No readback received")
+
     except Exception as e:
         safe_log(f"[WARN] Time sync failed: {e}")
 

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -24,7 +24,8 @@ static const ism_reg_t cc1101_cfg_rx[] = {
     {0x18, 0x08}, // MCSM0: FS_AUTOCAL=00 (no autocalibration) ← CHANGE
     {0x1E, 0x10}, // WOREVT1: EVENT0 high byte (0x1080 = 264ms)
     {0x1F, 0x80}, // WOREVT0: EVENT0 low byte
-    {0x20, 0x78}, // WORCTRL: RC_PD=0 (RC osc ON for WOR timing)
+    {0x20,
+     0x70}, // WORCTRL: WOR_RES=0, EVENT1=7, RC_PD=0 (RC osc ON), WOR_DBG=0
 };
 
 static const ism_reg_t cc1101_cfg_tx[] = {

--- a/STM32/Core/Inc/radio.h
+++ b/STM32/Core/Inc/radio.h
@@ -42,9 +42,14 @@ int Radio_Receive(uint8_t *out, size_t out_max);
 void Radio_EnterWOR(void);
 
 /**
- * @brief Start RX loop: continuously read RX FIFO and print.
+ * @brief Enter sleep mode.
  */
-void start_RX(void);
+void Radio_EnterSleep(void);
+
+/**
+ * @brief Enter idle mode.
+ */
+void Radio_EnterIdle(void);
 
 #ifdef __cplusplus
 }

--- a/STM32/Core/Src/ds3231.c
+++ b/STM32/Core/Src/ds3231.c
@@ -37,12 +37,12 @@ void DS3231_Init(void) {
 // Power on the DS3231 by setting the control pin high
 void DS3231_PowerOn(void) {
   HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_SET);
-  HAL_Delay(5);
+  HAL_Delay(10);
 }
 
 // Power off the DS3231 by setting the control pin low
 void DS3231_PowerOff(void) {
-  HAL_Delay(5);
+  HAL_Delay(10);
   HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET);
 }
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -739,7 +739,6 @@ int main(void) {
       // Stop transmission and go back to sleep
       stop_audio_transmission();
     }
-    complete_tick = HAL_GetTick() - wake_up_tick;
 
     if (OPERATION_MODE == 0) {
       LOGF("Has to wait for synchronization: %ld ms\r\n", (long)wait_ms);

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -409,7 +409,6 @@ int main(void) {
 
     // Power down CC1101 since we don't use it in standalone
     HAL_Delay(20);
-    uint8_t status = 0;
     CC1101_PowerUpReset();
     HAL_Delay(10);
 
@@ -475,7 +474,6 @@ int main(void) {
   uint32_t connection_tick = 0;
   uint32_t arm_tick = 0;
   uint32_t trigger_tick = 0;
-  uint32_t complete_tick = 0;
   uint32_t done_tick = 0;
   int32_t wait_ms = 0;
 

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -137,7 +137,7 @@ rtc_time_t now = {.seconds = 0,
                   .month = 1,
                   .year = 1970};
 
-int8_t temp_int = 25;
+int8_t temp_int = 99;
 
 static uint32_t sine_val_low[LUT_LOW_SAMPLES];
 static uint32_t sine_val_high[LUT_HIGH_SAMPLES];
@@ -175,6 +175,8 @@ extern volatile uint8_t cdc_rx_len;
 uint32_t wake_up_tick = 0;
 
 bool first_boot = true;
+
+extern USBD_HandleTypeDef hUsbDeviceFS;
 
 /* USER CODE END PV */
 
@@ -316,6 +318,7 @@ int main(void) {
   }
 
   DS3231_PowerOn();
+  DS3231_Init();
   DS3231_GetTime(&now);
   DS3231_ReadTemperature(&temp_int);
   DS3231_PowerOff();
@@ -784,6 +787,8 @@ int main(void) {
       LOGF("  Total ticks from wakeup to transmission start: %lu ms\r\n",
            (unsigned long)(done_tick - wake_up_tick));
     } else {
+      LOGF("RTC time at wakeup: %02d:%02d:%02d, %02d/%02d/%04d\r\n", now.hours,
+           now.minutes, now.seconds, now.date, now.month, now.year);
       LOGF("Timing for Standalone cycle:\r\n");
       LOGF("  Ticks from wakeup to while loop start: %lu ms\r\n",
            (unsigned long)(while_tick - wake_up_tick));
@@ -810,9 +815,15 @@ int main(void) {
       LOGF("  Total ticks from wakeup to audio trigger: %lu ms\r\n",
            (unsigned long)(trigger_tick - wake_up_tick));
     }
-    LOGF("Total ticks from wakeup to cycle complete: %lu ms\r\n",
-         (unsigned long)(complete_tick - wake_up_tick));
     LOGF("-------------------------\r\n");
+
+    // Get and print the time for drift analysis
+    DS3231_PowerOn();
+    DS3231_GetTime(&now);
+    DS3231_ReadTemperature(&temp_int);
+    DS3231_PowerOff();
+    LOGF("TRIGGER_TIME:%02d:%02d:%02d\r\n", now.hours, now.minutes,
+         now.seconds);
 
     /* USER CODE END WHILE */
 
@@ -1270,6 +1281,9 @@ void EnterStopMode(void) {
     HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
   }
 
+  USBD_Stop(&hUsbDeviceFS);
+  HAL_Delay(10);
+
   __DSB();
   __ISB();
   HAL_SuspendTick();
@@ -1280,6 +1294,11 @@ void EnterStopMode(void) {
   HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_SET);
   MX_I2C2_Init();
   MX_USART2_UART_Init();
+
+  // Stop USB before sleep, reinit after wakeup
+  MX_USB_Device_Init();
+  HAL_Delay(200); // Wait for USB enumeration
+
   HAL_Delay(10);
   HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_RESET);
   wake_up_tick = HAL_GetTick();
@@ -1884,12 +1903,21 @@ static void RTC_SetWakeupTimer(uint32_t seconds) {
 }
 
 void TryReceiveTimeSync(void) {
+  DS3231_PowerOn();
+  HAL_Delay(10);
+
   LOGF("Waiting for time sync (10s)...\r\n");
 
   char buf[32] = {0};
   uint32_t start = HAL_GetTick();
+  uint32_t last_ready = 0;
 
   while (HAL_GetTick() - start < 10000) {
+    if (HAL_GetTick() - last_ready >= 500) {
+      LOGF("READY_FOR_TIME_SYNC\r\n");
+      last_ready = HAL_GetTick();
+    }
+
     if (cdc_rx_len > 0) {
       uint8_t len = cdc_rx_len;
       cdc_rx_len = 0;
@@ -1908,25 +1936,8 @@ void TryReceiveTimeSync(void) {
         if (sscanf(buf + 1, "%d:%d:%d %d %d/%d/%d", &h, &m, &s, &dow, &day,
                    &mon, &year) == 7) {
 
-          uint32_t t0 = HAL_GetTick();
-
-          DS3231_PowerOn();
-          uint32_t t1 = HAL_GetTick();
-          LOGF("[TIMING] PowerOn: %lu ms\r\n", t1 - t0);
-
-          HAL_Delay(5);
-          uint32_t t2 = HAL_GetTick();
-
           DS3231_Init();
-          uint32_t t3 = HAL_GetTick();
-          LOGF("[TIMING] Init: %lu ms\r\n", t3 - t2);
-
           DS3231_SetTime(s, m, h, dow, day, mon, year);
-          uint32_t t4 = HAL_GetTick();
-          LOGF("[TIMING] SetTime: %lu ms\r\n", t4 - t3);
-          LOGF("[TIMING] Total: %lu ms\r\n", t4 - t0);
-
-          DS3231_PowerOff();
 
           LOGF("Time synced: %02d:%02d:%02d %02d/%02d/%04d\r\n", h, m, s, day,
                mon, year);
@@ -1937,8 +1948,10 @@ void TryReceiveTimeSync(void) {
         }
       }
     }
+
     HAL_Delay(10);
   }
+
   LOGF("No time sync received\r\n");
   LED_Toggle();
   HAL_Delay(50);
@@ -1946,6 +1959,7 @@ void TryReceiveTimeSync(void) {
   LED_Toggle();
   HAL_Delay(50);
   LED_Toggle();
+  DS3231_PowerOff();
 }
 
 /* USER CODE END 4 */

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -403,6 +403,16 @@ int main(void) {
     }
   } else {
     LOGF("No radio in standalone mode - skipping radio initialization\r\n");
+
+    // Power down CC1101 since we don't use it in standalone
+    HAL_Delay(20);
+    uint8_t status = 0;
+    CC1101_PowerUpReset();
+    HAL_Delay(10);
+
+    // Put it in sleep to save power
+    Radio_EnterSleep();
+    LOGF("CC1101 powered down for standalone mode\r\n");
   }
 
   //-----------------------------------------------------------------------------//
@@ -625,6 +635,7 @@ int main(void) {
 
     } else if (OPERATION_MODE == 1) {
       LOGF("Woke up for TX transmission\r\n");
+      Radio_EnterIdle();
 
       // Send transmission over radio
       LOGF("Starting transmission over radio...\r\n");
@@ -634,11 +645,14 @@ int main(void) {
 
       LED_ON();
       trigger_tick = HAL_GetTick() - wake_up_tick;
+
       Radio_Transmit();
 
       Relay_SetBypassMode();
       LED_OFF();
       done_tick = HAL_GetTick() - wake_up_tick;
+
+      Radio_EnterSleep();
     } else {
       LOGF("Woke up for Standalone mode\r\n");
 

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -223,3 +223,15 @@ void Radio_EnterWOR(void) {
   HAL_Delay(10);
   CC1101_Strobe(0x38, &status); // SWOR
 }
+
+void Radio_EnterSleep(void) {
+  uint8_t status = 0;
+  CC1101_Strobe(0x36, &status); // SIDLE
+  HAL_Delay(5);
+  CC1101_Strobe(0x39, &status); // SPWD
+}
+
+void Radio_EnterIdle(void) {
+  uint8_t status = 0;
+  CC1101_Strobe(0x36, &status); // SIDLE
+}

--- a/STM32/Core/Src/wakeup.c
+++ b/STM32/Core/Src/wakeup.c
@@ -25,13 +25,10 @@ void WakeUp_SetCurrentMinute(uint8_t minute) { current_minute = minute; }
 void WakeUp_CalculateNextValidMinute(void) {
   if (next_valid_minute == UNINITIALIZED) {
     if (ENABLE_DELAYED_START && current_minute != STARTING_MINUTE) {
-      // LOGF("Setting next valid minute to starting minute %02d\r\n",
-      //      STARTING_MINUTE);
       next_valid_minute = STARTING_MINUTE;
       return;
 
     } else {
-
       LOGF("No valid minute configured, setting next valid minute to current "
            "minute "
            "+ 1 (wraps around at 60)\r\n");
@@ -40,9 +37,6 @@ void WakeUp_CalculateNextValidMinute(void) {
       return;
     }
   } else {
-    // LOGF("Calculating next valid minute based on last valid minute %02d and "
-    //      "configured interval of %u minutes\r\n",
-    //      next_valid_minute, (unsigned int)INTERVAL_BETWEEN_REPEATS_MINUTES);
     next_valid_minute =
         (next_valid_minute + INTERVAL_BETWEEN_REPEATS_MINUTES) % 60;
   }


### PR DESCRIPTION
This pull request introduces significant improvements to the STM32 firmware and the Python GUI script, focusing on power management, radio/RTC handling, and robust time synchronization. The changes enhance device reliability, optimize power usage, and improve the accuracy and feedback of time sync operations.

**STM32 Firmware Improvements**

*Power management and radio handling:*
- Added new functions (`Radio_EnterSleep`, `Radio_EnterIdle`) to allow the CC1101 radio to enter low-power and idle states, and updated main logic to use these for better power saving, especially in standalone mode. [[1]](diffhunk://#diff-053abf93e5cd330ed130d2cd82a04d532208199a611a3894c2ef9dacd0799cd9L45-R52) [[2]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baR226-R237) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R409-R417) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R639) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R649-R656)
- Improved CC1101 configuration for WOR (Wake-on-Radio) by updating the `WORCTRL` register for more explicit control.

*RTC (DS3231) handling and time sync:*
- Increased delays after powering the DS3231 RTC for more reliable startup/shutdown, and ensured initialization occurs after powering on. [[1]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL40-R45) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R321)
- Refined the time synchronization process: now emits periodic `READY_FOR_TIME_SYNC` messages, powers the RTC only when needed, and powers off after sync attempts. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1903-R1917) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1897-L1915) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1948-R1959)

*USB and low-power mode:*
- Stopped the USB device before entering stop mode and reinitialized it after waking up, with appropriate delays for enumeration. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1281-R1283) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1294-R1298)

*Logging and timing improvements:*
- Enhanced logging for timing analysis, including RTC time at wakeup and after key events, and added drift analysis hooks. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R787-R788) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L799-R824)

**Python GUI Script Enhancements**

*Time synchronization robustness:*
- Overhauled the time sync process: waits for the device to signal readiness, sends the current time, waits for a readback, and verifies synchronization accuracy within 1 second. Improved feedback and error handling.
- Minor import fix for `timedelta`.

**Other Notable Changes**

- Cleaned up comments and removed unused variables for clarity and maintainability. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L465) [[2]](diffhunk://#diff-8290de9be0e768ecf975af120fd8cccb2191f7d63c594db265cfbff8e9b9dbe5L28-L34) [[3]](diffhunk://#diff-8290de9be0e768ecf975af120fd8cccb2191f7d63c594db265cfbff8e9b9dbe5L43-L45)
- Updated initial temperature variable and added an external USB device handle. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L140-R140) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R179-R180)
- Minor UI/UX tweak in the time sync message.
- Updated KiCad project view settings for improved usability.

---

**Most important changes:**

**Power management and radio/RTC handling**
- Added `Radio_EnterSleep` and `Radio_EnterIdle` functions, and updated main logic to put the CC1101 radio into low-power or idle states as appropriate, improving power efficiency in both normal and standalone modes. [[1]](diffhunk://#diff-053abf93e5cd330ed130d2cd82a04d532208199a611a3894c2ef9dacd0799cd9L45-R52) [[2]](diffhunk://#diff-3d1c3ca7e86fa9c572db3650eb938f599c28f657de862251d7a0c85e58aa65baR226-R237) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R409-R417) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R639) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R649-R656)
- Improved DS3231 RTC power cycling and initialization, with increased delays and correct sequencing to ensure reliable RTC operation. [[1]](diffhunk://#diff-1263112e5812b4ee9c26791c76b641eb5bb6a05b493369f38782dd05f6d2393fL40-R45) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R321)

**Time synchronization**
- Overhauled both device and Python GUI time sync logic: device now emits periodic readiness messages, powers RTC only as needed, and confirms sync with readback; Python script waits for readiness, sends time, waits for readback, and verifies sync accuracy. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1903-R1917) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L1897-L1915) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1948-R1959) [[4]](diffhunk://#diff-2f53b79684c03e61b5b06dd47e80aa91961e964cfdce6729b97e0411bcd2544eL246-R351)

**USB and low-power mode**
- Stopped USB device before entering stop mode and reinitialized it after wakeup, with delays to ensure proper USB enumeration. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1281-R1283) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R1294-R1298)

**Logging and timing**
- Improved logging for timing and drift analysis, including RTC time at wakeup and after key events, to aid in debugging and performance measurement. [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R787-R788) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L799-R824)

**Radio configuration**
- Updated CC1101 WORCTRL register configuration for more explicit and correct wake-on-radio behavior.