### PR TITLE
Enhance CC1101 functionality and improve status reporting

### DIFF
--- a/Python/gui/gui.py
+++ b/Python/gui/gui.py
@@ -1457,44 +1457,62 @@ class FlashToolApp(tk.Tk):
 
     def _run_build(self):
         try:
-            ok = build_flash(
+            status_code = build_flash(
                 self,
                 self.vars["show_log"],
                 self.widgets["build_btn"],
             )
 
-            if not ok:
-                self.after(0, lambda: self._finish_build(False, "❌ Build failed"))
-                return
-
-            self.after(
-                0,
-                lambda: self._finish_build(
-                    True,
-                    "✅ Build & Flash completed successfully!",
-                    show_popup=True,
-                ),
-            )
+            if status_code == 0:
+                self.after(
+                    0,
+                    lambda: self._finish_build(
+                        "success",
+                        "✅ Build & Flash completed successfully!",
+                    ),
+                )
+            elif status_code == 1:
+                self.after(
+                    0,
+                    lambda: self._finish_build(
+                        "time_sync_failed",
+                        "⚠️ Build & Flash succeeded, time sync failed",
+                    ),
+                )
+            else:
+                # Should not reach here, but handle gracefully
+                self.after(
+                    0,
+                    lambda: self._finish_build("failed", "❌ Build failed"),
+                )
 
         except Exception as e:
             self.after(
                 0,
-                lambda: self._finish_build(False, "❌ Build failed", error=str(e)),
+                lambda: self._finish_build("failed", "❌ Build failed", error=str(e)),
             )
 
-    def _finish_build(self, success, status_text, show_popup=False, error=None):
+    def _finish_build(self, result, status_text, error=None):
         self.widgets["progress"].stop()
-        dot = self.colors["success"] if success else "#ff5555"
-        self._set_status(status_text, dot_color=dot)
-        self.widgets["build_btn"].config(state="normal")
 
-        if show_popup:
-            messagebox.showinfo(
-                "Build & Flash", "Build and Flash completed successfully!"
+        if result == "success":
+            dot = self.colors["success"]
+            self.widgets["build_btn"].config(state="normal")
+            messagebox.showinfo("Success", "Build & Flash completed successfully!")
+        elif result == "time_sync_failed":
+            dot = "#ffaa33"  # Orange/amber warning
+            self.widgets["build_btn"].config(state="normal")
+            messagebox.showwarning(
+                "Partial Success",
+                "Build & Flash succeeded, but time sync failed.\nDevice time was not synchronized.",
             )
+        else:  # "failed"
+            dot = "#ff5555"
+            self.widgets["build_btn"].config(state="normal")
+            if error:
+                messagebox.showerror("Error", f"❌ {error}")
 
-        if error:
-            messagebox.showerror("Error", f"❌ {error}")
+        self._set_status(status_text, dot_color=dot)
 
         self.after(
             4000, lambda: self._set_status("Idle", dot_color=self.colors["muted"])

--- a/Python/gui/scripts/build.py
+++ b/Python/gui/scripts/build.py
@@ -262,7 +262,7 @@ def send_time_sync(root, safe_log):
 
     if not port:
         safe_log("[WARN] STM32 CDC port not found, skipping time sync")
-        return
+        return False
 
     try:
         with serial.Serial(port, 115200, timeout=10) as ser:
@@ -284,7 +284,7 @@ def send_time_sync(root, safe_log):
 
             if not ready:
                 safe_log("[WARN] Never received READY_FOR_TIME_SYNC")
-                return
+                return False
 
             # Sample time and send
             sent_time = datetime.now(UTC)
@@ -305,12 +305,15 @@ def send_time_sync(root, safe_log):
                         safe_log(f"[DEBUG] {line}")
                     if "Time synced:" in line:
                         safe_log("[INFO] Time sync successful!")
-                        return
+                        return True
                 except:
                     pass
 
+            return False
+
     except Exception as e:
         safe_log(f"[WARN] Time sync failed: {e}")
+        return False
 
 
 def build_flash(root, show_log_var, build_btn):
@@ -343,15 +346,19 @@ def build_flash(root, show_log_var, build_btn):
         build_only(log_text, safe_log)
         clear_flash_flag(log_text, safe_log)
         flash_only(log_text, safe_log, leave=True)  # don't leave, we detach manually
-        send_time_sync(root, safe_log)
+        time_sync_ok = send_time_sync(root, safe_log)
 
         safe_log("\n[SUCCESS] ✅ Build & flash complete!")
+
+        if not time_sync_ok:
+            build_btn.config(state="normal")
+            return 1
 
     except Exception as e:
         safe_log(f"\n[ERROR] ❌ {e}")
         messagebox.showerror("Error", f"Build/flash failed: {e}")
         build_btn.config(state="normal")
-        return False
+        return 2
 
     build_btn.config(state="normal")
-    return True
+    return 0

--- a/Python/gui/scripts/user_config.py
+++ b/Python/gui/scripts/user_config.py
@@ -163,8 +163,8 @@ def change_user_config(root, set_initial_time, safe_log=None):
         starting_minute_i = to_int("STARTING_MINUTE", starting_minute, 0, 59)
         end_hour_i = to_int("END_HOUR", end_hour, 0, 23)
         end_minute_i = to_int("END_MINUTE", end_minute, 0, 59)
-        run_minutes_i = to_int("RUN_MINUTES", run_minutes, 1, 1440)
-        sleep_minutes_i = to_int("SLEEP_MINUTES", sleep_minutes, 1, 1440)
+        run_minutes_i = to_int("RUN_MINUTES", run_minutes, 0, 1440)
+        sleep_minutes_i = to_int("SLEEP_MINUTES", sleep_minutes, 0, 1440)
 
         fsk_low_i = to_int("FSK_LOWER_FREQUENCY", frequency_lower, 1, 50000)
         fsk_high_i = to_int("FSK_HIGHER_FREQUENCY", frequency_higher, 1, 50000)

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -21,7 +21,8 @@ static const ism_reg_t cc1101_cfg_rx[] = {
     {0x12, 0x02}, // MDMCFG2
     {0x13, 0xF2}, // MDMCFG1: FEC enabled (bit 7 = 1)
     {0x17, 0x37}, // MCSM2: RX_TIME=7, EXITMASK enabled
-    {0x18, 0x08}, // MCSM0: FS_AUTOCAL=00 (no autocalibration) ← CHANGE
+    {0x18, 0x18}, // MCSM0: FS_AUTOCAL=01 (auto-calibrate when going from IDLE
+                  // to RX or TX), PO_TIMEOUT=0 (no timeout from RX/TX to IDLE)
     {0x1E, 0x10}, // WOREVT1: EVENT0 high byte (0x1080 = 264ms)
     {0x1F, 0x80}, // WOREVT0: EVENT0 low byte
     {0x20,
@@ -29,20 +30,19 @@ static const ism_reg_t cc1101_cfg_rx[] = {
 };
 
 static const ism_reg_t cc1101_cfg_tx[] = {
-    {0x02, 0x07}, // IOCFG0: GDO0 asserts when packet received with CRC OK,
-                  //         deasserts on first FIFO byte read
-    {0x04, 0xD3}, // SYNC1: sync word high byte = 0xD3
-    {0x05, 0x91}, // SYNC0: sync word low byte  = 0x91  must match RX
-    {0x06, 0x3D}, // PKTLEN: max packet length = 61 bytes
-    {0x07, 0x05}, // PKTCTRL1: address check enabled, no status bytes appended
-    {0x08, 0x05}, // PKTCTRL0: variable length, CRC enabled, no data whitening
-    {0x09, 0xEB}, // ADDR: device address = 0xEB
-    {0x0D, 0x10}, // FREQ2: carrier frequency high byte
-    {0x0E, 0xA7}, // FREQ1: carrier frequency mid byte
-    {0x0F, 0x62}, // FREQ0: carrier frequency low byte
-    {0x10, 0x85}, // MDMCFG4: channel BW=203kHz, DRATE_E=5 -> 1200 bps
-    {0x11, 0x83}, // MDMCFG3: DRATE_M=131 -> 1200 bps
-    {0x12,
-     0x02}, // MDMCFG2: 2-FSK, 16/16 sync word bits, no Manchester encoding
-    {0x13, 0xF2}, // MDMCFG1: 24-byte preamble (160ms at 1200 bps), FEC disabled
+    {0x02, 0x07}, // IOCFG0
+    {0x04, 0xD3}, // SYNC1
+    {0x05, 0x91}, // SYNC0
+    {0x06, 0x3D}, // PKTLEN
+    {0x07, 0x05}, // PKTCTRL1
+    {0x08, 0x05}, // PKTCTRL0
+    {0x09, 0xEB}, // ADDR
+    {0x0D, 0x10}, // FREQ2
+    {0x0E, 0xA7}, // FREQ1
+    {0x0F, 0x62}, // FREQ0
+    {0x10, 0x85}, // MDMCFG4
+    {0x11, 0x83}, // MDMCFG3
+    {0x12, 0x02}, // MDMCFG2
+    {0x13, 0xF2}, // MDMCFG1
+    {0x18, 0x18}, // ← ADD THIS: MCSM0 - autocalibrate on TX→RX/RX→TX
 };

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -5,8 +5,7 @@ typedef struct {
 } ism_reg_t;
 
 static const ism_reg_t cc1101_cfg_rx[] = {
-    {0x02, 0x07}, // IOCFG0: GDO0 asserts when packet received with CRC OK,
-                  // deasserts on first FIFO byte read
+    {0x02, 0x07}, // IOCFG0: GDO0 asserts when packet received
     {0x04, 0xD3}, // SYNC1
     {0x05, 0x91}, // SYNC0
     {0x06, 0x3D}, // PKTLEN
@@ -19,18 +18,17 @@ static const ism_reg_t cc1101_cfg_rx[] = {
     {0x10, 0x85}, // MDMCFG4
     {0x11, 0x83}, // MDMCFG3
     {0x12, 0x02}, // MDMCFG2
-    {0x13, 0xF2}, // MDMCFG1: FEC enabled (bit 7 = 1)
+    {0x13, 0xF2}, // MDMCFG1: FEC enabled
+    {0x14, 0x01}, // MDMCFG0: bit 0 = 1 enables external XTAL
     {0x17, 0x37}, // MCSM2: RX_TIME=7, EXITMASK enabled
-    {0x18, 0x18}, // MCSM0: FS_AUTOCAL=01 (auto-calibrate when going from IDLE
-                  // to RX or TX), PO_TIMEOUT=0 (no timeout from RX/TX to IDLE)
+    {0x18, 0x18}, // MCSM0: FS_AUTOCAL=01 (auto-calibrate on state transitions)
     {0x1E, 0x10}, // WOREVT1: EVENT0 high byte (0x1080 = 264ms)
     {0x1F, 0x80}, // WOREVT0: EVENT0 low byte
-    {0x20,
-     0x70}, // WORCTRL: WOR_RES=0, EVENT1=7, RC_PD=0 (RC osc ON), WOR_DBG=0
+    {0x20, 0x70}, // WORCTRL: WOR_RES=0, EVENT1=7, RC_PD=0 (RC osc OFF)
 };
 
 static const ism_reg_t cc1101_cfg_tx[] = {
-    {0x02, 0x07}, // IOCFG0
+    {0x02, 0x07}, // IOCFG0: GDO0 asserts when packet received
     {0x04, 0xD3}, // SYNC1
     {0x05, 0x91}, // SYNC0
     {0x06, 0x3D}, // PKTLEN
@@ -44,8 +42,6 @@ static const ism_reg_t cc1101_cfg_tx[] = {
     {0x11, 0x83}, // MDMCFG3
     {0x12, 0x02}, // MDMCFG2
     {0x13, 0xF2}, // MDMCFG1
-    {0x18, 0x18}, // AUTO_CAL=01 (auto-calibrate when going from IDLE to RX or
-                  // TX), PO_TIMEOUT=0
-                  // {0x3E, 0xC0}, // PA_TABLE0: 0xC0 = +10dBm
-                  // {0x22, 0x10}, // TEST2: 0x10 = +10dBm PA test setting
+    {0x14, 0x01}, // MDMCFG0: bit 0 = 1 enables external XTAL
+    {0x18, 0x18}, // MCSM0: FS_AUTOCAL=01 (auto-calibrate on state transitions)
 };

--- a/STM32/Core/Inc/cc1101_config.h
+++ b/STM32/Core/Inc/cc1101_config.h
@@ -44,5 +44,8 @@ static const ism_reg_t cc1101_cfg_tx[] = {
     {0x11, 0x83}, // MDMCFG3
     {0x12, 0x02}, // MDMCFG2
     {0x13, 0xF2}, // MDMCFG1
-    {0x18, 0x18}, // ← ADD THIS: MCSM0 - autocalibrate on TX→RX/RX→TX
+    {0x18, 0x18}, // AUTO_CAL=01 (auto-calibrate when going from IDLE to RX or
+                  // TX), PO_TIMEOUT=0
+                  // {0x3E, 0xC0}, // PA_TABLE0: 0xC0 = +10dBm
+                  // {0x22, 0x10}, // TEST2: 0x10 = +10dBm PA test setting
 };

--- a/STM32/Core/Inc/speaker.h
+++ b/STM32/Core/Inc/speaker.h
@@ -1,0 +1,23 @@
+#ifndef __SPEAKER_H
+#define __SPEAKER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stm32g4xx_hal.h>
+
+#define SPEAKER_GPIO_Port GPIOA
+#define SPEAKER_Pin GPIO_PIN_7
+#define SPEAKER_TOGGLE_DELAY_MS 140
+
+void Speaker_TurnOn(void);
+void Speaker_TurnOff(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SPEAKER_H */

--- a/STM32/Core/Src/cc1101.c
+++ b/STM32/Core/Src/cc1101.c
@@ -5,7 +5,10 @@
 #include <string.h>
 
 static inline void cs_low(void) { GPIOB->BSRR = ((uint32_t)BB_CS << 16); }
-static inline void cs_high(void) { GPIOB->BSRR = BB_CS; }
+static inline void cs_high(void) {
+  GPIOB->BSRR = BB_CS;
+  HAL_Delay(1); // Let MISO release
+}
 
 static bool is_miso_low(void) { return (GPIOB->IDR & BB_MISO) == 0; }
 
@@ -50,11 +53,13 @@ bool CC1101_PowerUpReset(void) {
   HAL_Delay(100);
 
   cs_low();
+  wait_miso_low(100);
   HAL_Delay(1);
   cs_high();
   HAL_Delay(10);
 
   cs_low();
+  wait_miso_low(100);
   bb_byte(0x30); // SRES
 
   // Try up to 5 times with increasing delays
@@ -75,6 +80,8 @@ bool CC1101_PowerUpReset(void) {
 
 HAL_StatusTypeDef CC1101_Strobe(uint8_t strobe, uint8_t *status) {
   cs_low();
+  wait_miso_low(100);
+
   uint8_t rx = bb_byte(strobe);
   cs_high();
   if (status)
@@ -84,6 +91,8 @@ HAL_StatusTypeDef CC1101_Strobe(uint8_t strobe, uint8_t *status) {
 
 HAL_StatusTypeDef CC1101_ReadReg(uint8_t addr, uint8_t *val, uint8_t *status) {
   cs_low();
+  wait_miso_low(100);
+
   uint8_t rx_status = bb_byte(addr | 0x80);
   uint8_t rx_val = bb_byte(0xFF);
   cs_high();
@@ -96,6 +105,8 @@ HAL_StatusTypeDef CC1101_ReadReg(uint8_t addr, uint8_t *val, uint8_t *status) {
 
 HAL_StatusTypeDef CC1101_WriteReg(uint8_t addr, uint8_t val, uint8_t *status) {
   cs_low();
+  wait_miso_low(100);
+
   uint8_t rx_status = bb_byte(addr & 0x7F);
   bb_byte(val);
   cs_high();
@@ -109,6 +120,8 @@ HAL_StatusTypeDef CC1101_WriteBurstReg(uint8_t addr, uint8_t *vals, size_t len,
   if (!vals || len == 0)
     return HAL_OK;
   cs_low();
+  wait_miso_low(100);
+
   uint8_t rx_status = bb_byte(addr | 0x40);
   for (size_t i = 0; i < len; i++)
     bb_byte(vals[i]);
@@ -123,6 +136,7 @@ HAL_StatusTypeDef CC1101_ReadBurstReg(uint8_t addr, uint8_t *vals, size_t len,
   if (!vals || len == 0)
     return HAL_OK;
   cs_low();
+  wait_miso_low(100);
   uint8_t rx_status = bb_byte(addr | 0xC0);
   for (size_t i = 0; i < len; i++)
     vals[i] = bb_byte(0xFF);

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -18,6 +18,7 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include "speaker.h"
 #include "usb_device.h"
 
 /* Private includes ----------------------------------------------------------*/
@@ -37,6 +38,7 @@
 #include "radio.h"
 #include "reed_solomon.h"
 #include "relay.h"
+#include "speaker.h"
 #include "user_config.h"
 #include "wakeup.h"
 
@@ -96,7 +98,7 @@
 #define OUTPUT_SEGMENT 500
 #define BUFFER_SIZE (OUTPUT_SEGMENT * 5)
 
-#define SYNC_DELAY_MS 200
+#define SYNC_DELAY_MS 250
 
 /* USER CODE END PD */
 
@@ -236,11 +238,10 @@ void TryReceiveTimeSync(void);
 /* USER CODE END 0 */
 
 /**
-  * @brief  The application entry point.
-  * @retval int
-  */
-int main(void)
-{
+ * @brief  The application entry point.
+ * @retval int
+ */
+int main(void) {
 
   /* USER CODE BEGIN 1 */
 
@@ -248,7 +249,8 @@ int main(void)
 
   /* MCU Configuration--------------------------------------------------------*/
 
-  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick.
+   */
   HAL_Init();
 
   /* USER CODE BEGIN Init */
@@ -539,8 +541,7 @@ int main(void)
         Opamps_Enable(&hdac1);
         Relay_SetMixingMode();
       } else {
-        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
-        HAL_Delay(100);
+        Speaker_TurnOn();
       }
 
       start_audio_arm();
@@ -654,8 +655,7 @@ int main(void)
         HAL_Delay(20);
         Relay_SetMixingMode();
       } else {
-        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
-        HAL_Delay(100);
+        Speaker_TurnOn();
       }
 
       start_audio_arm();
@@ -690,22 +690,22 @@ int main(void)
 }
 
 /**
-  * @brief System Clock Configuration
-  * @retval None
-  */
-void SystemClock_Config(void)
-{
+ * @brief System Clock Configuration
+ * @retval None
+ */
+void SystemClock_Config(void) {
   RCC_OscInitTypeDef RCC_OscInitStruct = {0};
   RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
 
   /** Configure the main internal regulator output voltage
-  */
+   */
   HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1);
 
   /** Initializes the RCC Oscillators according to the specified parameters
-  * in the RCC_OscInitTypeDef structure.
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI|RCC_OSCILLATORTYPE_LSI;
+   * in the RCC_OscInitTypeDef structure.
+   */
+  RCC_OscInitStruct.OscillatorType =
+      RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_LSI;
   RCC_OscInitStruct.HSIState = RCC_HSI_ON;
   RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
   RCC_OscInitStruct.LSIState = RCC_LSI_ON;
@@ -716,33 +716,30 @@ void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
   RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV4;
   RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     Error_Handler();
   }
 
   /** Initializes the CPU, AHB and APB buses clocks
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
+   */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                                RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV2;
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK)
-  {
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
     Error_Handler();
   }
 }
 
 /**
-  * @brief ADC1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_ADC1_Init(void)
-{
+ * @brief ADC1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ADC1_Init(void) {
 
   /* USER CODE BEGIN ADC1_Init 0 */
 
@@ -756,7 +753,7 @@ static void MX_ADC1_Init(void)
   /* USER CODE END ADC1_Init 1 */
 
   /** Common config
-  */
+   */
   hadc1.Instance = ADC1;
   hadc1.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
   hadc1.Init.Resolution = ADC_RESOLUTION_12B;
@@ -773,44 +770,39 @@ static void MX_ADC1_Init(void)
   hadc1.Init.DMAContinuousRequests = DISABLE;
   hadc1.Init.Overrun = ADC_OVR_DATA_PRESERVED;
   hadc1.Init.OversamplingMode = DISABLE;
-  if (HAL_ADC_Init(&hadc1) != HAL_OK)
-  {
+  if (HAL_ADC_Init(&hadc1) != HAL_OK) {
     Error_Handler();
   }
 
   /** Configure the ADC multi-mode
-  */
+   */
   multimode.Mode = ADC_MODE_INDEPENDENT;
-  if (HAL_ADCEx_MultiModeConfigChannel(&hadc1, &multimode) != HAL_OK)
-  {
+  if (HAL_ADCEx_MultiModeConfigChannel(&hadc1, &multimode) != HAL_OK) {
     Error_Handler();
   }
 
   /** Configure Regular Channel
-  */
+   */
   sConfig.Channel = ADC_CHANNEL_1;
   sConfig.Rank = ADC_REGULAR_RANK_1;
   sConfig.SamplingTime = ADC_SAMPLETIME_640CYCLES_5;
   sConfig.SingleDiff = ADC_SINGLE_ENDED;
   sConfig.OffsetNumber = ADC_OFFSET_NONE;
   sConfig.Offset = 0;
-  if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
-  {
+  if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN ADC1_Init 2 */
 
   /* USER CODE END ADC1_Init 2 */
-
 }
 
 /**
-  * @brief DAC1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_DAC1_Init(void)
-{
+ * @brief DAC1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_DAC1_Init(void) {
 
   /* USER CODE BEGIN DAC1_Init 0 */
 
@@ -823,15 +815,14 @@ static void MX_DAC1_Init(void)
   /* USER CODE END DAC1_Init 1 */
 
   /** DAC Initialization
-  */
+   */
   hdac1.Instance = DAC1;
-  if (HAL_DAC_Init(&hdac1) != HAL_OK)
-  {
+  if (HAL_DAC_Init(&hdac1) != HAL_OK) {
     Error_Handler();
   }
 
   /** DAC channel OUT1 config
-  */
+   */
   sConfig.DAC_HighFrequency = DAC_HIGH_FREQUENCY_INTERFACE_MODE_AUTOMATIC;
   sConfig.DAC_DMADoubleDataMode = DISABLE;
   sConfig.DAC_SignedFormat = DISABLE;
@@ -841,23 +832,20 @@ static void MX_DAC1_Init(void)
   sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
   sConfig.DAC_ConnectOnChipPeripheral = DAC_CHIPCONNECT_EXTERNAL;
   sConfig.DAC_UserTrimming = DAC_TRIMMING_FACTORY;
-  if (HAL_DAC_ConfigChannel(&hdac1, &sConfig, DAC_CHANNEL_1) != HAL_OK)
-  {
+  if (HAL_DAC_ConfigChannel(&hdac1, &sConfig, DAC_CHANNEL_1) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN DAC1_Init 2 */
 
   /* USER CODE END DAC1_Init 2 */
-
 }
 
 /**
-  * @brief I2C2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_I2C2_Init(void)
-{
+ * @brief I2C2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_I2C2_Init(void) {
 
   /* USER CODE BEGIN I2C2_Init 0 */
 
@@ -875,37 +863,32 @@ static void MX_I2C2_Init(void)
   hi2c2.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
   hi2c2.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
   hi2c2.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-  if (HAL_I2C_Init(&hi2c2) != HAL_OK)
-  {
+  if (HAL_I2C_Init(&hi2c2) != HAL_OK) {
     Error_Handler();
   }
 
   /** Configure Analogue filter
-  */
-  if (HAL_I2CEx_ConfigAnalogFilter(&hi2c2, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
-  {
+   */
+  if (HAL_I2CEx_ConfigAnalogFilter(&hi2c2, I2C_ANALOGFILTER_ENABLE) != HAL_OK) {
     Error_Handler();
   }
 
   /** Configure Digital filter
-  */
-  if (HAL_I2CEx_ConfigDigitalFilter(&hi2c2, 0) != HAL_OK)
-  {
+   */
+  if (HAL_I2CEx_ConfigDigitalFilter(&hi2c2, 0) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN I2C2_Init 2 */
 
   /* USER CODE END I2C2_Init 2 */
-
 }
 
 /**
-  * @brief RTC Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_RTC_Init(void)
-{
+ * @brief RTC Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_RTC_Init(void) {
 
   /* USER CODE BEGIN RTC_Init 0 */
 
@@ -916,7 +899,7 @@ static void MX_RTC_Init(void)
   /* USER CODE END RTC_Init 1 */
 
   /** Initialize RTC Only
-  */
+   */
   hrtc.Instance = RTC;
   hrtc.Init.HourFormat = RTC_HOURFORMAT_24;
   hrtc.Init.AsynchPrediv = 127;
@@ -926,15 +909,14 @@ static void MX_RTC_Init(void)
   hrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
   hrtc.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
   hrtc.Init.OutPutPullUp = RTC_OUTPUT_PULLUP_NONE;
-  if (HAL_RTC_Init(&hrtc) != HAL_OK)
-  {
+  if (HAL_RTC_Init(&hrtc) != HAL_OK) {
     Error_Handler();
   }
 
   /** Enable the WakeUp
-  */
-  if (HAL_RTCEx_SetWakeUpTimer_IT(&hrtc, 59, RTC_WAKEUPCLOCK_CK_SPRE_16BITS) != HAL_OK)
-  {
+   */
+  if (HAL_RTCEx_SetWakeUpTimer_IT(&hrtc, 59, RTC_WAKEUPCLOCK_CK_SPRE_16BITS) !=
+      HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN RTC_Init 2 */
@@ -943,16 +925,14 @@ static void MX_RTC_Init(void)
   HAL_RTCEx_DeactivateWakeUpTimer(&hrtc);
 
   /* USER CODE END RTC_Init 2 */
-
 }
 
 /**
-  * @brief TIM2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM2_Init(void)
-{
+ * @brief TIM2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_TIM2_Init(void) {
 
   /* USER CODE BEGIN TIM2_Init 0 */
 
@@ -970,34 +950,29 @@ static void MX_TIM2_Init(void)
   htim2.Init.Period = 24;
   htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
   htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_Base_Init(&htim2) != HAL_OK)
-  {
+  if (HAL_TIM_Base_Init(&htim2) != HAL_OK) {
     Error_Handler();
   }
   sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
-  if (HAL_TIM_ConfigClockSource(&htim2, &sClockSourceConfig) != HAL_OK)
-  {
+  if (HAL_TIM_ConfigClockSource(&htim2, &sClockSourceConfig) != HAL_OK) {
     Error_Handler();
   }
   sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
   sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig) != HAL_OK)
-  {
+  if (HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN TIM2_Init 2 */
 
   /* USER CODE END TIM2_Init 2 */
-
 }
 
 /**
-  * @brief TIM6 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM6_Init(void)
-{
+ * @brief TIM6 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_TIM6_Init(void) {
 
   /* USER CODE BEGIN TIM6_Init 0 */
 
@@ -1013,29 +988,25 @@ static void MX_TIM6_Init(void)
   htim6.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim6.Init.Period = 65535;
   htim6.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_Base_Init(&htim6) != HAL_OK)
-  {
+  if (HAL_TIM_Base_Init(&htim6) != HAL_OK) {
     Error_Handler();
   }
   sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
   sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(&htim6, &sMasterConfig) != HAL_OK)
-  {
+  if (HAL_TIMEx_MasterConfigSynchronization(&htim6, &sMasterConfig) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN TIM6_Init 2 */
 
   /* USER CODE END TIM6_Init 2 */
-
 }
 
 /**
-  * @brief USART2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_USART2_UART_Init(void)
-{
+ * @brief USART2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_USART2_UART_Init(void) {
 
   /* USER CODE BEGIN USART2_Init 0 */
 
@@ -1055,33 +1026,29 @@ static void MX_USART2_UART_Init(void)
   huart2.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
   huart2.Init.ClockPrescaler = UART_PRESCALER_DIV1;
   huart2.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
-  if (HAL_UART_Init(&huart2) != HAL_OK)
-  {
+  if (HAL_UART_Init(&huart2) != HAL_OK) {
     Error_Handler();
   }
-  if (HAL_UARTEx_SetTxFifoThreshold(&huart2, UART_TXFIFO_THRESHOLD_1_8) != HAL_OK)
-  {
+  if (HAL_UARTEx_SetTxFifoThreshold(&huart2, UART_TXFIFO_THRESHOLD_1_8) !=
+      HAL_OK) {
     Error_Handler();
   }
-  if (HAL_UARTEx_SetRxFifoThreshold(&huart2, UART_RXFIFO_THRESHOLD_1_8) != HAL_OK)
-  {
+  if (HAL_UARTEx_SetRxFifoThreshold(&huart2, UART_RXFIFO_THRESHOLD_1_8) !=
+      HAL_OK) {
     Error_Handler();
   }
-  if (HAL_UARTEx_DisableFifoMode(&huart2) != HAL_OK)
-  {
+  if (HAL_UARTEx_DisableFifoMode(&huart2) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN USART2_Init 2 */
 
   /* USER CODE END USART2_Init 2 */
-
 }
 
 /**
-  * Enable DMA controller clock
-  */
-static void MX_DMA_Init(void)
-{
+ * Enable DMA controller clock
+ */
+static void MX_DMA_Init(void) {
 
   /* DMA controller clock enable */
   __HAL_RCC_DMAMUX1_CLK_ENABLE();
@@ -1091,16 +1058,14 @@ static void MX_DMA_Init(void)
   /* DMA1_Channel1_IRQn interrupt configuration */
   HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
-
 }
 
 /**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_GPIO_Init(void)
-{
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_GPIO_Init(void) {
   GPIO_InitTypeDef GPIO_InitStruct = {0};
   /* USER CODE BEGIN MX_GPIO_Init_1 */
 
@@ -1112,23 +1077,26 @@ static void MX_GPIO_Init(void)
   __HAL_RCC_GPIOB_CLK_ENABLE();
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_1|GPIO_PIN_5|GPIO_PIN_6|GPIO_PIN_7
-                          |GPIO_PIN_10|GPIO_PIN_15, GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(GPIOA,
+                    GPIO_PIN_1 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 |
+                        GPIO_PIN_10 | GPIO_PIN_15,
+                    GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0|GPIO_PIN_3|GPIO_PIN_4|GPIO_PIN_6, GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0 | GPIO_PIN_3 | GPIO_PIN_4 | GPIO_PIN_6,
+                    GPIO_PIN_RESET);
 
   /*Configure GPIO pins : PA1 PA5 PA6 PA7
                            PA10 PA15 */
-  GPIO_InitStruct.Pin = GPIO_PIN_1|GPIO_PIN_5|GPIO_PIN_6|GPIO_PIN_7
-                          |GPIO_PIN_10|GPIO_PIN_15;
+  GPIO_InitStruct.Pin = GPIO_PIN_1 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 |
+                        GPIO_PIN_10 | GPIO_PIN_15;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
   /*Configure GPIO pins : PB0 PB3 PB4 PB6 */
-  GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_3|GPIO_PIN_4|GPIO_PIN_6;
+  GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_3 | GPIO_PIN_4 | GPIO_PIN_6;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
@@ -1547,7 +1515,7 @@ static void start_audio_trigger(void) {
 static void stop_audio_transmission(void) {
   tx_active = false;
 
-  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_RESET);
+  Speaker_TurnOff();
   Relay_SetBypassMode();
 
   // Stop trigger + DMA first
@@ -1847,11 +1815,10 @@ void TryReceiveTimeSync(void) {
 /* USER CODE END 4 */
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @retval None
-  */
-void Error_Handler(void)
-{
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
+void Error_Handler(void) {
   /* USER CODE BEGIN Error_Handler_Debug */
   LOGF("Error_Handler: code=%d\r\n", (int)g_error_code);
 
@@ -1871,14 +1838,13 @@ void Error_Handler(void)
 }
 #ifdef USE_FULL_ASSERT
 /**
-  * @brief  Reports the name of the source file and the source line number
-  *         where the assert_param error has occurred.
-  * @param  file: pointer to the source file name
-  * @param  line: assert_param error line source number
-  * @retval None
-  */
-void assert_failed(uint8_t *file, uint32_t line)
-{
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
+void assert_failed(uint8_t *file, uint32_t line) {
   /* USER CODE BEGIN 6 */
   /* User can add his own implementation to report the file name and line
      number, ex: printf("Wrong parameters value: file %s on line %d\r\n",

--- a/STM32/Core/Src/main.c
+++ b/STM32/Core/Src/main.c
@@ -1830,6 +1830,8 @@ void Error_Handler(void) {
   // Blink error code
   LED_BlinkStatusCode((uint8_t)g_error_code);
 
+  LED_ON();
+
   __disable_irq();
   while (1) {
     // Stay here - reset or power cycle needed

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -138,46 +138,64 @@ char *Radio_BuildPayload(uint32_t offset_ms) {
 
   return strdup(temp_buf);
 }
-
 void Radio_Transmit(void) {
   LOGF("Starting radio transmission...\r\n");
   uint8_t status = 0;
-  uint32_t t0 = HAL_GetTick(); // Capture once before loop
+  uint32_t t0 = HAL_GetTick();
 
   for (int tx_repeat = 0; tx_repeat < 1; tx_repeat++) {
     const char *payload_str = Radio_BuildPayload(HAL_GetTick() - t0);
     size_t payload_len = strlen(payload_str);
 
-    LOGF("TX %d payload: %s\r\n", tx_repeat + 1, payload_str);
+    LOGF("TX payload: %s\r\n", payload_str);
 
     uint8_t pkt[2 + payload_len];
     pkt[0] = payload_len + 1;
     pkt[1] = 0xEB;
     memcpy(&pkt[2], payload_str, payload_len);
 
-    LOGF("TX payload_len=%d pkt_size=%d\r\n", payload_len, 2 + payload_len);
-    LOGF("TX payload: %s\r\n", payload_str);
+    LOGF("Packet size: %zu bytes\r\n", sizeof(pkt));
 
-    CC1101_Strobe(0x3B, &status); // SFTX: flush TX FIFO
+    // Flush FIFO
+    CC1101_Strobe(0x3B, &status);
+    HAL_Delay(2);
 
+    // Check TXBYTES before write
+    uint8_t txbytes_before = 0;
+    CC1101_ReadReg(0xFA, &txbytes_before, &status);
+    LOGF("TXBYTES before write: 0x%02X\r\n", txbytes_before);
+
+    // Write FIFO
     CC1101_WriteBurstReg(0x3F, pkt, sizeof(pkt), &status);
-    if (status != 0x0F) {
-      LOGF("Error writing to TX FIFO, status: 0x%02X\r\n", status);
-      Error_Handler_Code(STATUS_CODE_TRANSMISSION_ERROR);
+    LOGF("WriteBurstReg status: 0x%02X\r\n", status);
+
+    // Check TXBYTES after write
+    uint8_t txbytes_after = 0;
+    CC1101_ReadReg(0xFA, &txbytes_after, &status);
+    LOGF("TXBYTES after write: 0x%02X (expect 0x%02X)\r\n", txbytes_after,
+         sizeof(pkt));
+
+    if ((txbytes_after & 0x7F) == 0) {
+      LOGF("ERROR: FIFO write failed!\r\n");
       return;
     }
 
-    CC1101_Strobe(0x35, &status); // STX
+    // Issue STX
+    LOGF("Issuing STX...\r\n");
+    CC1101_Strobe(0x35, &status);
+
+    HAL_Delay(5);
+    uint8_t marcstate = 0;
+    CC1101_ReadReg(0xF5, &marcstate, &status);
+    marcstate &= 0x1F;
+    LOGF("MARCSTATE after STX: 0x%02X\r\n", marcstate);
 
     // Wait for TX to complete
-    uint32_t tx_timeout = HAL_GetTick() + 2000; // 2 second timeout
-    uint8_t marcstate = 0;
-
+    uint32_t tx_timeout = HAL_GetTick() + 2000;
     while (HAL_GetTick() < tx_timeout) {
       CC1101_ReadReg(0xF5, &marcstate, &status);
       marcstate &= 0x1F;
 
-      // 0x13 = TX, 0x0D = RX (TX finished, transitioned back), 0x01 = IDLE
       if (marcstate != 0x13) {
         LOGF("TX complete, MARCSTATE=0x%02X\r\n", marcstate);
         break;
@@ -186,20 +204,17 @@ void Radio_Transmit(void) {
     }
 
     if (marcstate == 0x13) {
-      LOGF("TX timeout - packet may not have sent\r\n");
+      LOGF("TX timeout\r\n");
     }
 
     free((void *)payload_str);
   }
 
-  // ← ADD FROM HERE
   HAL_Delay(100);
   uint8_t post_tx_marcstate = 0;
   CC1101_ReadReg(0xF5, &post_tx_marcstate, &status);
   post_tx_marcstate &= 0x1F;
-  LOGF("Post-TX MARCSTATE: 0x%02X (should be 0x0D or 0x01)\r\n",
-       post_tx_marcstate);
-  // ← TO HERE
+  LOGF("Post-TX MARCSTATE: 0x%02X\r\n", post_tx_marcstate);
 }
 
 int Radio_Receive(uint8_t *out, size_t out_max_len) {

--- a/STM32/Core/Src/radio.c
+++ b/STM32/Core/Src/radio.c
@@ -169,21 +169,37 @@ void Radio_Transmit(void) {
 
     CC1101_Strobe(0x35, &status); // STX
 
-    // DEBUG: Check TX state
+    // Wait for TX to complete
+    uint32_t tx_timeout = HAL_GetTick() + 2000; // 2 second timeout
     uint8_t marcstate = 0;
-    HAL_Delay(50);
-    CC1101_ReadReg(0xF5, &marcstate, &status);
-    marcstate &= 0x1F;
-    LOGF("DEBUG: After STX strobe, MARCSTATE=0x%02X ", marcstate);
-    if (marcstate == 0x13)
-      LOGF("(TX)\r\n");
-    else if (marcstate == 0x01)
-      LOGF("(IDLE - TX failed)\r\n");
-    else
-      LOGF("(UNKNOWN)\r\n");
+
+    while (HAL_GetTick() < tx_timeout) {
+      CC1101_ReadReg(0xF5, &marcstate, &status);
+      marcstate &= 0x1F;
+
+      // 0x13 = TX, 0x0D = RX (TX finished, transitioned back), 0x01 = IDLE
+      if (marcstate != 0x13) {
+        LOGF("TX complete, MARCSTATE=0x%02X\r\n", marcstate);
+        break;
+      }
+      HAL_Delay(10);
+    }
+
+    if (marcstate == 0x13) {
+      LOGF("TX timeout - packet may not have sent\r\n");
+    }
 
     free((void *)payload_str);
   }
+
+  // ← ADD FROM HERE
+  HAL_Delay(100);
+  uint8_t post_tx_marcstate = 0;
+  CC1101_ReadReg(0xF5, &post_tx_marcstate, &status);
+  post_tx_marcstate &= 0x1F;
+  LOGF("Post-TX MARCSTATE: 0x%02X (should be 0x0D or 0x01)\r\n",
+       post_tx_marcstate);
+  // ← TO HERE
 }
 
 int Radio_Receive(uint8_t *out, size_t out_max_len) {

--- a/STM32/Core/Src/relay.c
+++ b/STM32/Core/Src/relay.c
@@ -6,7 +6,7 @@
 #define RELAY_GPIO_Port GPIOA
 #define RELAY_PIN_ON GPIO_PIN_6
 #define RELAY_PIN_OFF GPIO_PIN_5
-#define RELAY_TOGGLE_DELAY_MS 100
+#define RELAY_TOGGLE_DELAY_MS 140
 
 void Relay_ResetBoth(void) {
   HAL_GPIO_WritePin(RELAY_GPIO_Port, RELAY_PIN_ON, GPIO_PIN_RESET);

--- a/STM32/Core/Src/speaker.c
+++ b/STM32/Core/Src/speaker.c
@@ -1,0 +1,13 @@
+#include "speaker.h"
+#include "log.h"
+
+#include <stm32g4xx_hal.h>
+
+void Speaker_TurnOn(void) {
+  HAL_GPIO_WritePin(SPEAKER_GPIO_Port, SPEAKER_Pin, GPIO_PIN_SET);
+  HAL_Delay(SPEAKER_TOGGLE_DELAY_MS);
+}
+
+void Speaker_TurnOff(void) {
+  HAL_GPIO_WritePin(SPEAKER_GPIO_Port, SPEAKER_Pin, GPIO_PIN_RESET);
+}

--- a/STM32/extra_sources.cmake
+++ b/STM32/extra_sources.cmake
@@ -12,6 +12,7 @@ file(GLOB USER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/radio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/reed_solomon.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/relay.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/speaker.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/wakeup.c
 )
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the STM32 firmware and the Python GUI. The most significant changes include improved handling and reporting of time synchronization during the build/flash process, enhanced reliability for CC1101 SPI communication, configuration updates for the CC1101 radio, and the introduction of a new `speaker.h` abstraction for speaker control. There are also minor code style and validation improvements.

**Python GUI and Build Process Improvements:**

* The build and flash process now returns a status code instead of a boolean, allowing the GUI to distinguish between complete success, partial success (build/flash succeeded but time sync failed), and failure. The GUI now displays appropriate messages and colors for each outcome, improving user feedback. (`Python/gui/gui.py`, `Python/gui/scripts/build.py`) [[1]](diffhunk://#diff-b2edb84b7a452046e08ccd501b7dd478afd63db190af50605a5e9f05e8d7cb1eL1460-R1516) [[2]](diffhunk://#diff-2f53b79684c03e61b5b06dd47e80aa91961e964cfdce6729b97e0411bcd2544eL265-R265) [[3]](diffhunk://#diff-2f53b79684c03e61b5b06dd47e80aa91961e964cfdce6729b97e0411bcd2544eL287-R287) [[4]](diffhunk://#diff-2f53b79684c03e61b5b06dd47e80aa91961e964cfdce6729b97e0411bcd2544eL308-R316) [[5]](diffhunk://#diff-2f53b79684c03e61b5b06dd47e80aa91961e964cfdce6729b97e0411bcd2544eL346-R364)
* Validation for `RUN_MINUTES` and `SLEEP_MINUTES` in user configuration now allows zero as a valid value, fixing a bug where "0" was rejected. (`Python/gui/scripts/user_config.py`)

**CC1101 Radio Communication Reliability:**

* Added `wait_miso_low` calls and short delays after chip-select transitions in all CC1101 SPI routines to improve communication reliability and ensure the MISO line is ready before data transfer. (`STM32/Core/Src/cc1101.c`) [[1]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709L8-R11) [[2]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709R56-R62) [[3]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709R83-R84) [[4]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709R94-R95) [[5]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709R108-R109) [[6]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709R123-R124) [[7]](diffhunk://#diff-8d990fb892608ed80b21b740cf0072e0a112a9a94003cd33b898c0e03221e709R139)

**CC1101 Configuration Updates:**

* Updated CC1101 RX and TX register settings: enabled external crystal oscillator, set FS_AUTOCAL for automatic calibration on state transitions, and clarified comments. These changes improve radio stability and performance. (`STM32/Core/Inc/cc1101_config.h`) [[1]](diffhunk://#diff-396008bce731cb9cfeca601e60d25c5a33d3f209b63bcfd058ba4e715f8999adL8-R8) [[2]](diffhunk://#diff-396008bce731cb9cfeca601e60d25c5a33d3f209b63bcfd058ba4e715f8999adL22-R46)

**Speaker Abstraction and Code Cleanup:**

* Introduced a new `speaker.h` interface and replaced direct GPIO calls with the `Speaker_TurnOn()` function, improving code maintainability and abstraction. (`STM32/Core/Inc/speaker.h`, `STM32/Core/Src/main.c`) [[1]](diffhunk://#diff-80172c544b5bde7c70b1f1891dfdd91422066532f29c51f39a2dcbd5778659d0R1-R23) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R21) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3R41) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L542-R544) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L657-R658)
* Minor code style improvements and formatting in `main.c`, such as consistent brace placement and multi-line statements. (`STM32/Core/Src/main.c`) [[1]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L242-R253) [[2]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L696-R696) [[3]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L708-R708) [[4]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L719-R732) [[5]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L744-R742) [[6]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L776-R780) [[7]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L797-R805) [[8]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L828-R820) [[9]](diffhunk://#diff-a30058a4230390e1015209e38b6cffc250e10ed3cd5ad2c6199c3251df5075c3L99-R101)

These changes collectively improve the robustness, maintainability, and user experience of both the firmware and the GUI.