### PR TITLE
Fix Pylance type errors and average repeated autotest runs in plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dist/
 results/
 
 Testing/test_files/demodulator_autotest/*
+
+pyrightconfig.json

--- a/Testing/scripts/autotest.py
+++ b/Testing/scripts/autotest.py
@@ -79,7 +79,7 @@ def _pink_noise(rng: np.random.Generator, n: int) -> np.ndarray:
         [0.049922035, -0.095993537, 0.050612699, -0.004408786], dtype=np.float64
     )
     a = np.array([1.0, -2.494956002, 2.017265875, -0.522189400], dtype=np.float64)
-    pink = lfilter(b, a, white)
+    pink = np.asarray(lfilter(b, a, white))
     del white  # free early — lfilter is done with it
     std = float(pink.std()) or 1.0
     pink /= std
@@ -213,7 +213,7 @@ def run_subfolder(
 # ── Main ───────────────────────────────────────────────────────────────────
 
 
-def main() -> None:
+def main() -> int:
     suite_dir = os.path.join(BASE_DIR, INPUT_FOLDER)
     subfolders = sorted(
         d
@@ -238,6 +238,7 @@ def main() -> None:
 
         for folder in subfolders:
             m = FOLDER_RE.match(folder)
+            assert m is not None
             f0 = float(m.group(1))
             f1 = float(m.group(2))
             fp = os.path.join(suite_dir, folder)
@@ -327,6 +328,7 @@ def main() -> None:
             snr_value = "" if snr_db is None else snr_db
             for folder in subfolders:
                 m = FOLDER_RE.match(folder)
+                assert m is not None
                 f0 = float(m.group(1))
                 f1 = float(m.group(2))
                 total, status, _, _ = all_results[label][folder]

--- a/Testing/scripts/helper/plot_autotest.py
+++ b/Testing/scripts/helper/plot_autotest.py
@@ -55,13 +55,36 @@ def find_and_plot():
             print(f"No autotest_*.csv files found in {results_dir}")
             sys.exit(1)
 
+    # Group files sharing the same prefix (autotest_<testtype>_) in the same directory
+    groups: dict[tuple, list[str]] = collections.defaultdict(list)
     for path in csv_files:
-        print(f"Loading {path}")
-        rows = load_csv(path)
-        if not any(r["snr_db"] is not None for r in rows):
-            print(f"  Skipping {path} (no SNR values)")
+        dir_ = os.path.dirname(path)
+        basename = os.path.basename(path)
+        m = re.match(r"(autotest_[A-Za-z]+_)", basename)
+        prefix = m.group(1) if m else basename
+        groups[(dir_, prefix)].append(path)
+
+    for (dir_, prefix), paths in sorted(groups.items()):
+        all_rows = []
+        valid_paths = []
+        for path in sorted(paths):
+            print(f"Loading {path}")
+            rows = load_csv(path)
+            if not any(r["snr_db"] is not None for r in rows):
+                print(f"  Skipping {path} (no SNR values)")
+                continue
+            all_rows.extend(rows)
+            valid_paths.append(path)
+
+        if not all_rows:
             continue
-        plot(rows, [path])
+
+        if len(valid_paths) == 1:
+            plot(all_rows, valid_paths)
+        else:
+            print(f"Averaging {len(valid_paths)} files with prefix '{prefix}'")
+            avg_csv = os.path.join(dir_, prefix + "averaged.csv")
+            plot(all_rows, [avg_csv])
 
 
 def plot(all_rows, csv_paths):


### PR DESCRIPTION
- Wrap lfilter() result in np.asarray() so Pylance resolves .std() correctly
- Change main() return type from None to int to match return 0 statements
- Add assert m is not None after FOLDER_RE.match() (subfolders are pre-filtered)
- Group autotest CSV files by prefix (autotest_<type>_) before plotting so multiple runs are averaged into a single curve instead of plotted separately
- Add pyrightconfig.json to .gitignore