### PR TITLE
Automate toolchain setup and fix path issues in configuration

### DIFF
--- a/Software/gui/STM32Tool.spec
+++ b/Software/gui/STM32Tool.spec
@@ -12,7 +12,7 @@ a = Analysis(
         ('tools/dfu-util/dfu-util', 'tools/dfu-util'),
     ],
     datas=[
-        ('../../STM32', 'STM32'),
+        ('../../Firmware', 'Firmware'),
         ('tools', 'tools'),
     ],
     hiddenimports=[],

--- a/Software/gui/scripts/paths.py
+++ b/Software/gui/scripts/paths.py
@@ -13,22 +13,22 @@ if getattr(sys, "frozen", False):
         RESOURCES_DIR = os.path.abspath(
             os.path.join(os.path.dirname(sys.executable), "..", "Resources")
         )
-        PROJECT_SRC = os.path.join(RESOURCES_DIR, "STM32")
+        PROJECT_SRC = os.path.join(RESOURCES_DIR, "Firmware")
         TOOLS_DIR = os.path.join(RESOURCES_DIR, "tools")
 
         if not os.path.exists(PROJECT_SRC):
-            messagebox.showerror("Error", f"STM32 folder not found: {PROJECT_SRC}")
+            messagebox.showerror("Error", f"Firmware folder not found: {PROJECT_SRC}")
             sys.exit(1)
 
     # Windows/Linux build
     else:
         BASE = sys._MEIPASS
-        PROJECT_SRC = os.path.join(BASE, "STM32")
+        PROJECT_SRC = os.path.join(BASE, "Firmware")
         TOOLS_DIR = os.path.join(BASE, "tools")
 else:
     # Running from source
     BASE = os.path.dirname(__file__)
-    PROJECT_SRC = os.path.abspath(os.path.join(BASE, "../../../STM32"))
+    PROJECT_SRC = os.path.abspath(os.path.join(BASE, "../../../Firmware"))
     TOOLS_DIR = os.path.join(BASE, "..", "tools")
 
 

--- a/Software/gui/setup_toolchain.sh
+++ b/Software/gui/setup_toolchain.sh
@@ -1,40 +1,108 @@
 #!/bin/bash
 set -e
 
-# Where this script lives (Python/gui)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TOOLS_DIR="${SCRIPT_DIR}/tools"
+mkdir -p "${TOOLS_DIR}"
 
-# Toolchain version + download info
+# ─────────────────────────────────────────────
+# ARM GNU Toolchain
+# ─────────────────────────────────────────────
 TOOLCHAIN_VERSION=13.2.rel1
 TOOLCHAIN_NAME=arm-gnu-toolchain-${TOOLCHAIN_VERSION}-darwin-arm64-arm-none-eabi
 TOOLCHAIN_TAR=${TOOLCHAIN_NAME}.tar.xz
 TOOLCHAIN_URL=https://developer.arm.com/-/media/Files/downloads/gnu/${TOOLCHAIN_VERSION}/binrel/${TOOLCHAIN_TAR}
+TOOLCHAIN_DEST="${TOOLS_DIR}/arm-none-eabi-gcc"
 
-# Destination
-DEST_DIR="${TOOLS_DIR}/arm-none-eabi-gcc"
-
-echo "👉 Setting up ARM GNU Toolchain in ${DEST_DIR}"
-
-# Make sure tools folder exists
-mkdir -p "${TOOLS_DIR}"
-
-# Remove old version if exists
-rm -rf "${DEST_DIR}"
-
-# Download tarball if missing
-if [ ! -f "${TOOLS_DIR}/${TOOLCHAIN_TAR}" ]; then
-    echo "⬇️  Downloading ${TOOLCHAIN_TAR} ..."
-    curl -L -o "${TOOLS_DIR}/${TOOLCHAIN_TAR}" "${TOOLCHAIN_URL}"
+if [ ! -f "${TOOLCHAIN_DEST}/bin/arm-none-eabi-gcc" ]; then
+    echo ">>> ARM GNU Toolchain"
+    rm -rf "${TOOLCHAIN_DEST}"
+    if [ ! -f "${TOOLS_DIR}/${TOOLCHAIN_TAR}" ]; then
+        echo "  Downloading ${TOOLCHAIN_TAR}..."
+        curl -L -o "${TOOLS_DIR}/${TOOLCHAIN_TAR}" "${TOOLCHAIN_URL}"
+    fi
+    echo "  Extracting..."
+    tar -xf "${TOOLS_DIR}/${TOOLCHAIN_TAR}" -C "${TOOLS_DIR}"
+    mv "${TOOLS_DIR}/${TOOLCHAIN_NAME}" "${TOOLCHAIN_DEST}"
+    echo "  Done: ${TOOLCHAIN_DEST}/bin/arm-none-eabi-gcc"
 else
-    echo "✅ Already downloaded: ${TOOLCHAIN_TAR}"
+    echo "OK  ARM GNU Toolchain"
 fi
 
-# Extract inside tools/
-echo "📦 Extracting..."
-tar -xf "${TOOLS_DIR}/${TOOLCHAIN_TAR}" -C "${TOOLS_DIR}"
+# ─────────────────────────────────────────────
+# CMake 4.1.2
+# ─────────────────────────────────────────────
+CMAKE_VERSION=4.1.2
+CMAKE_NAME=cmake-${CMAKE_VERSION}-macos-universal
+CMAKE_TAR=${CMAKE_NAME}.tar.gz
+CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TAR}
+CMAKE_DEST="${TOOLS_DIR}/cmake/${CMAKE_VERSION}"
 
-# Rename to standard folder name
-mv "${TOOLS_DIR}/${TOOLCHAIN_NAME}" "${DEST_DIR}"
+if [ ! -f "${CMAKE_DEST}/bin/cmake" ]; then
+    echo ">>> CMake ${CMAKE_VERSION}"
+    rm -rf "${CMAKE_DEST}"
+    mkdir -p "${TOOLS_DIR}/cmake"
+    if [ ! -f "${TOOLS_DIR}/${CMAKE_TAR}" ]; then
+        echo "  Downloading ${CMAKE_TAR}..."
+        curl -L -o "${TOOLS_DIR}/${CMAKE_TAR}" "${CMAKE_URL}"
+    fi
+    echo "  Extracting..."
+    tar -xf "${TOOLS_DIR}/${CMAKE_TAR}" -C "${TOOLS_DIR}"
+    # The macOS tarball nests binaries inside CMake.app; normalise to a flat unix layout
+    EXTRACTED="${TOOLS_DIR}/${CMAKE_NAME}"
+    if [ -d "${EXTRACTED}/CMake.app/Contents" ]; then
+        mv "${EXTRACTED}/CMake.app/Contents" "${CMAKE_DEST}"
+        rm -rf "${EXTRACTED}"
+    else
+        mv "${EXTRACTED}" "${CMAKE_DEST}"
+    fi
+    echo "  Done: ${CMAKE_DEST}/bin/cmake"
+else
+    echo "OK  CMake ${CMAKE_VERSION}"
+fi
 
-echo "✅ Toolchain ready at: ${DEST_DIR}/bin/arm-none-eabi-gcc"
+# ─────────────────────────────────────────────
+# Ninja 1.13.1
+# ─────────────────────────────────────────────
+NINJA_VERSION=1.13.1
+NINJA_ZIP=ninja-mac.zip
+NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/${NINJA_ZIP}
+NINJA_DEST="${TOOLS_DIR}/ninja/ninja"
+
+if [ ! -f "${NINJA_DEST}" ]; then
+    echo ">>> Ninja ${NINJA_VERSION}"
+    mkdir -p "${TOOLS_DIR}/ninja"
+    if [ ! -f "${TOOLS_DIR}/${NINJA_ZIP}" ]; then
+        echo "  Downloading ${NINJA_ZIP}..."
+        curl -L -o "${TOOLS_DIR}/${NINJA_ZIP}" "${NINJA_URL}"
+    fi
+    echo "  Extracting..."
+    unzip -o "${TOOLS_DIR}/${NINJA_ZIP}" -d "${TOOLS_DIR}/ninja"
+    chmod +x "${NINJA_DEST}"
+    echo "  Done: ${NINJA_DEST}"
+else
+    echo "OK  Ninja ${NINJA_VERSION}"
+fi
+
+# ─────────────────────────────────────────────
+# dfu-util 0.11  (requires libusb — installed via Homebrew)
+# ─────────────────────────────────────────────
+DFU_DEST="${TOOLS_DIR}/dfu-util/dfu-util"
+
+if [ ! -f "${DFU_DEST}" ]; then
+    echo ">>> dfu-util"
+    mkdir -p "${TOOLS_DIR}/dfu-util"
+    if ! command -v brew &>/dev/null; then
+        echo "  ERROR: Homebrew not found. Install it from https://brew.sh then re-run."
+        exit 1
+    fi
+    brew install dfu-util
+    BREW_DFU="$(brew --prefix dfu-util)/bin/dfu-util"
+    cp "${BREW_DFU}" "${DFU_DEST}"
+    echo "  Done: ${DFU_DEST}"
+else
+    echo "OK  dfu-util"
+fi
+
+echo ""
+echo "All tools ready in ${TOOLS_DIR}"


### PR DESCRIPTION
This pull request updates the STM32 GUI toolchain setup and project structure to standardize the naming of the firmware directory and streamline toolchain installation. The most significant changes include renaming all references from `STM32` to `Firmware`, and a major overhaul of the `setup_toolchain.sh` script to automate the installation of required build tools (ARM GCC, CMake, Ninja, and dfu-util).

**Directory and Path Standardization:**

* All references to the `STM32` directory have been renamed to `Firmware` across the build specification (`STM32Tool.spec`), Python paths (`paths.py`), and resource checks to ensure consistency and prevent confusion. [[1]](diffhunk://#diff-4e642214f82dcb5a76fc342a918b9dd5eaa8eac3b9d05ac7ef3d1a7599c0629aL15-R15) [[2]](diffhunk://#diff-8207ee868fed6a48086eeae18cf59aef72f2dfabcb47d73474f556c737cadc37L16-R31)

**Toolchain Setup Improvements:**

* The `setup_toolchain.sh` script has been significantly expanded to automate downloading and installing the following tools into the `tools` directory:
  - ARM GNU Toolchain
  - CMake (with macOS-specific extraction logic)
  - Ninja build system
  - dfu-util (installed via Homebrew and copied locally)
  This makes the setup process more robust and user-friendly, reducing manual steps for developers.